### PR TITLE
add saving/restoring history to/from SharedPreferences

### DIFF
--- a/and-bible/app/src/main/java/net/bible/android/view/activity/base/CurrentActivityHolder.java
+++ b/and-bible/app/src/main/java/net/bible/android/view/activity/base/CurrentActivityHolder.java
@@ -40,12 +40,12 @@ public class CurrentActivityHolder {
 	public void iAmNoLongerCurrent(Activity activity) {
 		// if the next activity has not already overwritten my registration 
 		if (currentActivity!=null && currentActivity.equals(activity)) {
-			Log.w(TAG, "Temporarily null current ativity");
-			currentActivity = null;
 			if (appIsInForeground) {
 				appIsInForeground = false;
 				EventBus.getDefault().post(new AppToBackgroundEvent(Position.BACKGROUND));
 			}
+			Log.w(TAG, "Temporarily null current ativity");
+			currentActivity = null;
 		}
 	}
 	

--- a/and-bible/app/src/main/java/net/bible/service/history/HistoryItem.java
+++ b/and-bible/app/src/main/java/net/bible/service/history/HistoryItem.java
@@ -18,4 +18,7 @@ public interface HistoryItem {
 	// do back to the state at this point
 	public abstract void revertTo();
 
+	// if this Item came from SharedPreferences, we shouldn't go to it at Back key pressed
+	public abstract boolean isFromPersistentHistory();
+
 }

--- a/and-bible/app/src/main/java/net/bible/service/history/HistoryItemBase.java
+++ b/and-bible/app/src/main/java/net/bible/service/history/HistoryItemBase.java
@@ -24,4 +24,10 @@ public abstract class HistoryItemBase implements HistoryItem {
 	public Window getScreen() {
 		return window;
 	}
+
+	// only KeyHistoryItem can be serialized/deserialized to SharedPrefs, so return false for all other childs
+	@Override
+	public boolean isFromPersistentHistory() {
+		return false;
+	}
 }

--- a/and-bible/app/src/main/java/net/bible/service/history/HistoryManager.java
+++ b/and-bible/app/src/main/java/net/bible/service/history/HistoryManager.java
@@ -195,6 +195,8 @@ public class HistoryManager {
 	}
 
 	private void loadHistoryFromPersitent(Stack<HistoryItem> historyStack){
+		if(windowControl.isMultiWindow())
+			return;
 		final Activity currentActivity = CurrentActivityHolder.getInstance().getCurrentActivity();
 		SharedPreferences history = currentActivity.getSharedPreferences(HISTORY_STR, Context.MODE_PRIVATE);
 		int originalI = history.getInt(TOP_STR, -1);

--- a/and-bible/app/src/main/java/net/bible/service/history/HistoryManager.java
+++ b/and-bible/app/src/main/java/net/bible/service/history/HistoryManager.java
@@ -9,6 +9,7 @@ import java.util.Stack;
 
 import net.bible.android.control.ControlFactory;
 import net.bible.android.control.event.ABEventBus;
+import net.bible.android.control.event.apptobackground.AppToBackgroundEvent;
 import net.bible.android.control.event.passage.BeforeCurrentPageChangeEvent;
 import net.bible.android.control.page.CurrentPage;
 import net.bible.android.control.page.window.Window;
@@ -70,6 +71,23 @@ public class HistoryManager {
     public void onEvent(BeforeCurrentPageChangeEvent event) {
     	beforePageChange();
     }
+
+	public void onEvent(AppToBackgroundEvent event){
+		if (event.isMovedToBackground()){
+			// save history here
+			for (HistoryItem item: getHistoryStack()){
+				if (item instanceof KeyHistoryItem){
+					KeyHistoryItem keyItem = (KeyHistoryItem) item;
+					// We should ckeck that item not already saved.
+					// It possible when item alredy saved during this session or originally came from persistent.
+					if (!keyItem.isFromPersistentHistory() && !keyItem.isSavedToPersistent()) {
+						saveHistoryToPersistent(keyItem);
+						keyItem.setSavedToPersistent(true);
+					}
+				}
+			}
+		}
+	}
 	
 	public boolean canGoBack() {
 		if(getHistoryStack().size()>0)
@@ -98,8 +116,6 @@ public class HistoryManager {
 		if (!isGoingBack) {
 			HistoryItem item = createHistoryItem();
 			add(getHistoryStack(), item);
-			if (item instanceof KeyHistoryItem)
-				saveHistoryToPersistent((KeyHistoryItem) item); // save to SharedPreferences
 		}
 	}
 	private HistoryItem createHistoryItem() {

--- a/and-bible/app/src/main/java/net/bible/service/history/KeyHistoryItem.java
+++ b/and-bible/app/src/main/java/net/bible/service/history/KeyHistoryItem.java
@@ -30,8 +30,17 @@ public class KeyHistoryItem extends HistoryItemBase {
 	}
 
 	private boolean fromPersistent;
+	private boolean savedToPersistent = false;
 
-	private static final String TAG = "KeyHistoryItem"; 
+	public boolean isSavedToPersistent() {
+		return savedToPersistent;
+	}
+
+	public void setSavedToPersistent(boolean savedToPersistent) {
+		this.savedToPersistent = savedToPersistent;
+	}
+
+	private static final String TAG = "KeyHistoryItem";
 
 	public KeyHistoryItem(Book doc, Key verse, float yOffsetRatio) {
 		super();

--- a/and-bible/app/src/main/java/net/bible/service/history/KeyHistoryItem.java
+++ b/and-bible/app/src/main/java/net/bible/service/history/KeyHistoryItem.java
@@ -20,6 +20,17 @@ public class KeyHistoryItem extends HistoryItemBase {
 	private Key key;
 	private float yOffsetRatio;
 
+	@Override
+	public boolean isFromPersistentHistory() {
+		return fromPersistent;
+	}
+
+	public void setFromPersistent(boolean fromPersistent) {
+		this.fromPersistent = fromPersistent;
+	}
+
+	private boolean fromPersistent;
+
 	private static final String TAG = "KeyHistoryItem"; 
 
 	public KeyHistoryItem(Book doc, Key verse, float yOffsetRatio) {
@@ -93,5 +104,9 @@ public class KeyHistoryItem extends HistoryItemBase {
 		} else if (!key.equals(other.key))
 			return false;
 		return true;
+	}
+
+	public Book getDoc() {
+		return document;
 	}
 }


### PR DESCRIPTION
Now during work every history item saves to SharedPreferences.
At creation of history stack elements reads from SharedPreferences.
