### PR TITLE
Avoid multiple consecutive spaces when copying verse

### DIFF
--- a/app/src/main/java/net/bible/service/format/osistohtml/osishandlers/OsisToCanonicalTextSaxHandler.java
+++ b/app/src/main/java/net/bible/service/format/osistohtml/osishandlers/OsisToCanonicalTextSaxHandler.java
@@ -162,7 +162,7 @@ public class OsisToCanonicalTextSaxHandler extends OsisSaxHandler {
 		// reduce amount of whitespace becasue a lot of space was occurring between verses in ESVS and several other books
 		if (!StringUtils.isWhitespace(s)) {
 			super.write(s);
-			spaceJustWritten = false;
+			spaceJustWritten = Character.isWhitespace(s.charAt(s.length() - 1));
 		} else if (!spaceJustWritten) {
 			super.write(" ");
 			spaceJustWritten = true;


### PR DESCRIPTION
This change avoids a situation where copying Bible verses (in particular from Psalms or Proverbs) resulted in multiple consecutive space characters being copied to the clipboard within a verse.

**Steps to reproduce (example):**

1) Open Psalms 1 in WEBBE (World English Bible British English)
2) long-press on verse 1 -> it is highlighted
3) open context menu -> "Copy"
4) paste the verse into any other app and observe the result

**Result:**

The following text is copied:

    Psalms 1:1
    Blessed is the man who doesn't walk in the counsel of the wicked,  nor stand on the path of sinners, nor sit in the seat of scoffers;  

Note in particular, that there are two consecutive spaces after the first comma ("... wicked,`<space><space>`nor stand ...")

**Expected result:** Only a single comma should be there ("... wicked,`<space>`nor stand ...").


The reason is that the text "Blessed is the man who doesn’t walk in the counsel of the wicked, " is copied first, and then an additional explicit space character, before the next part of the verse ("nor sit in the seat of scoffers; ") is copied. (Additional explicit space characters are already ommitted.)

Avoiding the two consecutive spaces to copied right away avoids the need to manually edit the text after copying.