### PR TITLE
set View.SYSTEM_UI_FLAG_LAYOUT_STABLE flag when enabling fullscreen mode

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -510,29 +510,28 @@ class MainBibleActivity : CustomTitlebarActivityBase(), VerseActionModeMediator.
     private val sharedActivityState = SharedActivityState.getInstance()
 
     private fun hideSystemUI() {
-        window.decorView.systemUiVisibility = if(isPortrait) (
+        var uiFlags = (View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+            or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+            or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            or View.SYSTEM_UI_FLAG_FULLSCREEN)
 
-                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                //or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                or View.SYSTEM_UI_FLAG_FULLSCREEN)
-        else(
-                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                //or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                or View.SYSTEM_UI_FLAG_FULLSCREEN)
+        // only hide navigation bar in portrait mode
+        if (isPortrait)
+            uiFlags = (uiFlags or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION)
+
+        window.decorView.systemUiVisibility = uiFlags
     }
 
     private fun showSystemUI() {
-        window.decorView.systemUiVisibility = if (isPortrait) {
-            (View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-            or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-            //or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-            )
-        }
-        else View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+        var uiFlags = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+            or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN)
+
+        // only need to un-hide navigation bar in portrait mode
+        if (isPortrait)
+            uiFlags = (uiFlags or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
+
+        window.decorView.systemUiVisibility = uiFlags
     }
 
     private fun updateSpeakTransportVisibility() {


### PR DESCRIPTION
In hideSystemUI/showSystemUi, systemUiVisibility was previously set without View.SYSTEM_UI_FLAG_LAYOUT_STABLE (it was commented out, but I'm not sure why). The result is that when AndBible goes into fullscreen mode, the navigation bar background disappears immediately, and the remaining icons then slide downward, which is visually distracting and unattractive.

Setting the View.SYSTEM_UI_FLAG_LAYOUT_STABLE flag results in Android making the navigation bar background and icons slide downward and fade out together instead. I also did a little code refactoring to make the code a little easier to read and understand (in my opinion).