### PR TITLE
Fix Reading plan can't open if user has no Commentaries or Bibles ins…

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/readingplan/actionbar/ReadingPlanBibleActionBarButton.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/actionbar/ReadingPlanBibleActionBarButton.kt
@@ -32,7 +32,7 @@ import javax.inject.Inject
 class ReadingPlanBibleActionBarButton @Inject
 constructor() : ReadingPlanQuickDocumentChangeButton() {
 
-    override fun getSuggestedDocument(): Book {
+    override fun getSuggestedDocument(): Book? {
         return currentPageManager.currentBible.currentDocument
     }
 }

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/actionbar/ReadingPlanCommentaryActionBarButton.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/actionbar/ReadingPlanCommentaryActionBarButton.kt
@@ -32,7 +32,7 @@ class ReadingPlanCommentaryActionBarButton @Inject
 constructor() : ReadingPlanQuickDocumentChangeButton() {
 
 
-    override fun getSuggestedDocument(): Book {
+    override fun getSuggestedDocument(): Book? {
         return currentPageManager.currentCommentary.currentDocument
     }
 


### PR DESCRIPTION
A small fix that crashed app when opening Reading Plan and no commentaries installed.
