### PR TITLE
Localize reference name according to book language

### DIFF
--- a/app/src/main/java/net/bible/service/format/osistohtml/osishandlers/OsisToCopyTextSaxHandler.kt
+++ b/app/src/main/java/net/bible/service/format/osistohtml/osishandlers/OsisToCopyTextSaxHandler.kt
@@ -26,7 +26,7 @@ import org.crosswire.jsword.book.OSISUtil
 import org.xml.sax.Attributes
 
 /**
- * Convert OSIS input into Canonical text (for copying and sharing verses)
+ * Convert OSIS input into text (for copying and sharing verses)
  *
  * @author Timmy Braun [tim.bze at gmail dot com] (4/24/2019)
  */


### PR DESCRIPTION
Closes #358 

Fixed issue below. And added extra line break between reference and Scripture.
Also replaced depreciated android.text.Clipboard with android.content.Clipboard

Copied text from Finnish bible:

```
Revelation of John 9:13-15
13. Kuudes enkeli puhalsi torveen. Kuulin yhden äänen tulevan kultaisen alttarin neljästä sarvesta, Jumalan edestä, 14. ja ääni sanoi kuudennelle enkelille, jolla oli torvi: "Päästä ne neljä enkeliä, jotka ovat sidottuina suurella Eufrat-virralla." 15. Silloin päästettiin neljä enkeliä, jotka hetkelleen, päivälleen, kuukaudelleen ja vuodelleen olivat valmiina tappamaan kolmannen osan ihmisistä. 
```

Should be:

```
Ilmestyskirja 9:13-15

13. Kuudes enkeli puhalsi torveen. Kuulin yhden äänen tulevan kultaisen alttarin neljästä sarvesta, Jumalan edestä, 14. ja ääni sanoi kuudennelle enkelille, jolla oli torvi: "Päästä ne neljä enkeliä, jotka ovat sidottuina suurella Eufrat-virralla." 15. Silloin päästettiin neljä enkeliä, jotka hetkelleen, päivälleen, kuukaudelleen ja vuodelleen olivat valmiina tappamaan kolmannen osan ihmisistä. 
```