### PR TITLE
Improvements to maximize mode

### DIFF
--- a/app/src/main/java/net/bible/android/control/page/window/WindowControl.kt
+++ b/app/src/main/java/net/bible/android/control/page/window/WindowControl.kt
@@ -288,17 +288,23 @@ open class WindowControl @Inject constructor(
     }
 
     fun restoreWindow(window: Window) {
+        if (window == activeWindow) return
+
         var switchingMaximised = false
         windowRepository.maximisedScreens.forEach {
             switchingMaximised = true
             it.windowLayout.state = WindowState.MINIMISED
         }
-        
-        window.windowLayout.state = if (switchingMaximised) WindowState.MAXIMISED
-        else WindowState.SPLIT
+
+        window.isMaximised = switchingMaximised
 
         // causes BibleViews to be created and laid out
         eventManager.post(NumberOfWindowsChangedEvent(windowChapterVerseMap))
+
+        if (switchingMaximised) {
+            activeWindow = window
+            if (!activeWindow.initialized) PassageChangeMediator.getInstance().forcePageUpdate()
+        }
 
         windowSync.setResynchRequired(true)
         windowSync.synchronizeScreens()

--- a/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
+++ b/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
@@ -97,7 +97,15 @@ open class WindowRepository @Inject constructor(
     val minimisedScreens: List<Window>
         get() = getWindows(WindowState.MINIMISED)
 
-    private val isMaximisedState: Boolean
+    val minimisedAndMaximizedScreens: List<Window>
+    get() {
+        val ws = ArrayList<Window>()
+        ws.addAll(getWindows(WindowState.MINIMISED))
+        ws.addAll(getWindows(WindowState.MAXIMISED))
+        return ws.sortedBy { it.screenNo }
+    }
+
+    val isMaximisedState: Boolean
         get() {
             for (window in windows) {
                 if (window.windowLayout.state === WindowState.MAXIMISED) {

--- a/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
+++ b/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
@@ -94,14 +94,8 @@ open class WindowRepository @Inject constructor(
     val maximisedScreens: List<Window>
         get() = getWindows(WindowState.MAXIMISED)
 
-
-    // if a window is maximised then show no minimised windows
     val minimisedScreens: List<Window>
-        get() = if (isMaximisedState) {
-            ArrayList()
-        } else {
-            getWindows(WindowState.MINIMISED)
-        }
+        get() = getWindows(WindowState.MINIMISED)
 
     private val isMaximisedState: Boolean
         get() {

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -917,6 +917,9 @@ class MainBibleActivity : CustomTitlebarActivityBase(), VerseActionModeMediator.
         PassageChangeMediator.getInstance().forcePageUpdate()
         requestSdcardPermission()
         invalidateOptionsMenu()
+        windowControl.windowRepository.minimisedScreens.forEach {
+            it.initialized = false
+        }
         ABEventBus.getDefault().post(SynchronizeWindowsEvent())
     }
 

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -66,6 +66,7 @@ import net.bible.android.view.activity.base.ActivityBase
 import net.bible.android.view.activity.base.CurrentActivityHolder
 import net.bible.android.view.activity.base.CustomTitlebarActivityBase
 import net.bible.android.view.activity.base.Dialogs
+import net.bible.android.view.activity.base.IntentHelper
 import net.bible.android.view.activity.base.SharedActivityState
 import net.bible.android.view.activity.bookmark.Bookmarks
 import net.bible.android.view.activity.navigation.ChooseDictionaryWord
@@ -864,6 +865,10 @@ class MainBibleActivity : CustomTitlebarActivityBase(), VerseActionModeMediator.
                     windowControl.activeWindowPageManager.currentPage.key = verse
                     return
                 }
+            }
+            IntentHelper.UPDATE_SUGGESTED_DOCUMENTS_ON_FINISH -> {
+                // return from download documents. Do nothing
+                return
             }
             else -> throw RuntimeException("Unhandled request code $requestCode")
         }

--- a/app/src/main/java/net/bible/android/view/activity/page/screen/DocumentWebViewBuilder.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/screen/DocumentWebViewBuilder.kt
@@ -43,6 +43,7 @@ import net.bible.android.activity.R
 import net.bible.android.control.document.DocumentControl
 import net.bible.android.control.event.ABEventBus
 import net.bible.android.control.event.passage.CurrentVerseChangedEvent
+import net.bible.android.control.event.window.CurrentWindowChangedEvent
 import net.bible.android.control.event.window.NumberOfWindowsChangedEvent
 import net.bible.android.control.page.window.Window
 import net.bible.android.control.page.window.Window.WindowOperation
@@ -316,6 +317,11 @@ class DocumentWebViewBuilder @Inject constructor(
     }
 
     fun onEvent(event: MainBibleActivity.TransportBarVisibilityChanged) {
+        toggleWindowButtonVisibility(true, force=true)
+        resetTouchTimer()
+    }
+
+    fun onEvent(event: CurrentWindowChangedEvent) {
         toggleWindowButtonVisibility(true, force=true)
         resetTouchTimer()
     }

--- a/app/src/main/res/drawable/window_button_active.xml
+++ b/app/src/main/res/drawable/window_button_active.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2019 Martin Denham, Tuomas Airaksinen and the And Bible contributors.
+  ~
+  ~ This file is part of And Bible (http://github.com/AndBible/and-bible).
+  ~
+  ~ And Bible is free software: you can redistribute it and/or modify it under the
+  ~ terms of the GNU General Public License as published by the Free Software Foundation,
+  ~ either version 3 of the License, or (at your option) any later version.
+  ~
+  ~ And Bible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with And Bible.
+  ~ If not, see http://www.gnu.org/licenses/.
+  ~
+  -->
+
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle"
+    >
+    <corners android:radius="6dp" />
+    <stroke android:width="3dp" android:color="?attr/windowButtonStrokeColor" />
+
+    <solid android:color="?attr/windowButtonActiveBackgroundColor"/>
+    <padding android:left="8dp"
+        android:top="4dp"
+        android:right="8dp"
+        android:bottom="4dp" />
+</shape>
+
+

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -30,6 +30,7 @@
     <declare-styleable name="windowButtonTheme">
         <attr name="windowButtonStrokeColor" format="color"/>
         <attr name="windowButtonBackgroundColor" format="color"/>
+        <attr name="windowButtonActiveBackgroundColor" format="color"/>
     </declare-styleable>
     <declare-styleable name="bibleReferenceOverlayTheme">
         <attr name="bibleReferenceOverlayBackgroundColor" format="color"/>

--- a/app/src/main/res/values/barstyles.xml
+++ b/app/src/main/res/values/barstyles.xml
@@ -18,6 +18,7 @@
 		<item name="transportButtonColor">#ffffff</item>
 		<item name="windowButtonStrokeColor">#80FFFFFF</item>
 		<item name="windowButtonBackgroundColor">#B78D8D8D</item>
+		<item name="windowButtonActiveBackgroundColor">#B7000000</item>
 		<item name="bibleReferenceOverlayBackgroundColor">#DEEEEEEE</item>
 
 		<item name="speakTransportBackground">#FFFFFF</item>
@@ -32,6 +33,7 @@
 		<item name="transportButtonColor">#d4d4d4</item>
 		<item name="windowButtonStrokeColor">#80000000</item>
 		<item name="windowButtonBackgroundColor">#9b6e6e6e</item>
+		<item name="windowButtonActiveBackgroundColor">#9B313131</item>
 		<item name="bibleReferenceOverlayBackgroundColor">#DE3A3A3A</item>
 		<item name="speakTransportBackground">#000000</item>
 		<item name="transportBarHeight">75dp</item>

--- a/app/src/test/java/net/bible/android/control/page/window/WindowControlTest.kt
+++ b/app/src/test/java/net/bible/android/control/page/window/WindowControlTest.kt
@@ -1,14 +1,12 @@
 package net.bible.android.control.page.window
 
 import android.view.Menu
-import android.view.MenuItem
 
 import net.bible.android.TestBibleApplication
 import net.bible.android.activity.R
 import net.bible.android.control.event.EventManager
 import net.bible.android.control.event.window.NumberOfWindowsChangedEvent
 import net.bible.android.control.mynote.MyNoteDAO
-import net.bible.android.control.page.CurrentBiblePage
 import net.bible.android.control.page.CurrentPageManager
 import net.bible.android.control.page.window.WindowLayout.WindowState
 import net.bible.android.control.versification.BibleTraverser
@@ -17,7 +15,6 @@ import net.bible.service.sword.SwordDocumentFacade
 import net.bible.test.DatabaseResetter
 import net.bible.test.PassageTestData
 
-import org.crosswire.jsword.book.Book
 import org.crosswire.jsword.book.Books
 import org.crosswire.jsword.passage.Key
 import org.crosswire.jsword.passage.Verse
@@ -168,9 +165,9 @@ class WindowControlTest {
         windowControl!!.minimiseWindow(newWindow2)
         assertThat(windowRepository!!.minimisedScreens, contains(newWindow2))
 
-        // 1 window is minimised, but because a window is maximised no windows should be returned
+        // A window is maximized, the others should then all be minimized.
         windowControl!!.maximiseWindow(activeWindow)
-        assert(windowRepository!!.minimisedScreens.isEmpty())
+        assertThat<List<Window>>(windowRepository!!.minimisedScreens, containsInAnyOrder(newWindow1, newWindow2))
     }
 
     @Test


### PR DESCRIPTION
Closes #353 
Closes #364
In maximized mode:
- show all other windows as "minimized" windows.
- Clicking "minimized" windows, switches that particular window to maximized mode
- To get out of maximized mode, click the 3-line button on top right and uncheck "Maximize" box.

Allows easy flipping between windows if you want to work in maximized mode.