### PR TITLE
Fixes #337 This fix prevents blank screen from happening

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/screen/DocumentWebViewBuilder.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/screen/DocumentWebViewBuilder.kt
@@ -54,6 +54,7 @@ import net.bible.android.view.activity.page.MainBibleActivity
 import java.util.*
 
 import javax.inject.Inject
+import kotlin.math.max
 
 
 /**
@@ -164,7 +165,7 @@ class DocumentWebViewBuilder @Inject constructor(
                 // trigger recalc of verse positions in case width changes e.g. minimize/restore web view
                 bibleView.setVersePositionRecalcRequired(true)
 
-                val windowWeight = window.windowLayout.weight
+                val windowWeight = max(window.windowLayout.weight, 0.05F)
                 val lp = if (isSplitHorizontally)
                     LinearLayout.LayoutParams(LayoutParams.MATCH_PARENT, 0, windowWeight)
                 else


### PR DESCRIPTION
Closes #337
This fix prevents blank screen from happening. But it does not prevent slider bar from being able to move outside of visible screen. When slider bar has been moved outside of visible screen, add or remove a window and it will come back in. Possibly it will have to be switched to full screen to see bar.

Also, if 2 separator bars have been moved all the way together, on window add or remove they will be separated by a little space. I think that's a good thing, but I could prevent that from happening if others don't agree.
