### PR TITLE
Exclude external files in automatic Google app backup

### DIFF
--- a/app/src/main/res/xml/backup_descriptor.xml
+++ b/app/src/main/res/xml/backup_descriptor.xml
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
+    <exclude domain="external" path="." />
 </full-backup-content>


### PR DESCRIPTION
Closes #365 

This PR is required for Google app backup to work, because Google has a limit of 25mb per app. With downloaded modules, this quota is exceeded very quickly and then there are no backups to Google drive.

Google app backup saves preferences, bookmarks, notes, and reading plan status.

NOTE: User must have Backup to Google Drive enabled in Device Settings (available from Android 6.0)