### PR TITLE
Bugfix/#433 handle duplicate file names user reading plans

### DIFF
--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -66,6 +66,23 @@ class ReadingPlanControl @Inject constructor(
     val readingPlanList: List<ReadingPlanInfoDto>
         get() = readingPlanDao.readingPlanList
 
+    /**
+     * Check if any user plans in jsword/readingplan have same file
+     * name as one of the default plans
+     */
+    val readingPlanUserDuplicates: Boolean
+    get() {
+        val userPlanList = readingPlanDao.userPlanCodes(false)
+        userPlanList ?: return false
+
+        val internalPlanList = readingPlanDao.internalPlanCodes
+        userPlanList.forEach { userPlan ->
+            if (internalPlanList.find { internalPlan -> internalPlan == userPlan } != null)
+                return true
+        }
+        return false
+    }
+
     /** get list of days and readings for a plan so user can see the plan in advance
      */
     val currentPlansReadingList: List<OneDaysReadingsDto>

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -72,9 +72,7 @@ class ReadingPlanControl @Inject constructor(
      */
     val readingPlanUserDuplicates: Boolean
     get() {
-        val userPlanList = readingPlanDao.userPlanCodes(false)
-        userPlanList ?: return false
-
+        val userPlanList = readingPlanDao.userPlanCodes(false) ?: return false
         val internalPlanList = readingPlanDao.internalPlanCodes
         userPlanList.forEach { userPlan ->
             if (internalPlanList.find { internalPlan -> internalPlan == userPlan } != null)

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
@@ -59,6 +59,8 @@ class ReadingPlanSelectorList : ListActivityBase() {
         buildActivityComponent().inject(this)
         try {
             mReadingPlanList = readingPlanControl.readingPlanList
+            if (readingPlanControl.readingPlanUserDuplicates)
+                Dialogs.getInstance().showErrorMsg(getString(R.string.plan_duplicate_user_plan))
 
             mPlanArrayAdapter = ReadingPlanItemAdapter(this, LIST_ITEM_TYPE, mReadingPlanList)
             listAdapter = mPlanArrayAdapter

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
@@ -72,22 +72,43 @@ class ReadingPlanDao {
         @Throws(IOException::class)
         get() {
 
-            val resources = BibleApplication.application.resources
-            val assetManager = resources.assets
-
             val allCodes = ArrayList<String>()
 
-            val internalPlans = assetManager.list(READING_PLAN_FOLDER)
+            val internalPlans = internalPlanCodes
 			if(internalPlans != null) {
-				allCodes.addAll(getReadingPlanCodes(internalPlans))
+				allCodes.addAll(internalPlans)
 			}
 
-            val userPlans = USER_READING_PLAN_FOLDER.list()
+            val userPlans = userPlanCodes()
             if(userPlans != null) {
-                allCodes.addAll(getReadingPlanCodes(userPlans))
+                allCodes.addAll(userPlans)
             }
 
             return allCodes
+        }
+
+    val internalPlanCodes: List<String>
+        @Throws(IOException::class)
+        get() {
+            val resources = BibleApplication.application.resources
+            val assetManager = resources.assets
+            val internalPlans = assetManager.list(READING_PLAN_FOLDER)
+            return getReadingPlanCodes(internalPlans!!)
+        }
+
+    fun userPlanCodes(filterDuplicates: Boolean = true): List<String>? {
+            val userPlans = USER_READING_PLAN_FOLDER.list()
+            return if (userPlans != null) {
+                if (filterDuplicates) {
+                    getReadingPlanCodes(userPlans).filter { userPlan ->
+                        userPlan != internalPlanCodes.find { internalPlan -> internalPlan == userPlan }
+                    }
+                } else {
+                    getReadingPlanCodes(userPlans)
+                }
+            } else {
+                null
+            }
         }
 
     /** get a list of all days readings in a plan

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,7 +196,7 @@ TODO: error and download_document_confirm_prefix need to be parameterized rather
     <string name="plan_duplicate_user_plan">
         There is a user reading plan in sdcard
         jsword/readingplan with the same name as an internal plan. It can not be listed here.
-        Please rename the file to something else, leaving it's file extension as .properties
+        Please rename the file to something else, leaving it\'s file extension as .properties
     </string>
     <string name="plan_name_y1ntpspr">NT, Psalms &amp; Proverbs in a Year</string>
     <string name="plan_description_y1ntpspr">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,7 +195,7 @@ TODO: error and download_document_confirm_prefix need to be parameterized rather
     <string name="reset">Reset</string>
     <string name="plan_duplicate_user_plan">There is a user reading plan in sdcard
         jsword/readingplan with the same name as an internal plan. It can not be listed here.
-        Please rename the file to something else but leave it as .properties</string>
+        Please rename the file to something else, leaving it's file extension as .properties</string>
     <string name="plan_name_y1ntpspr">NT, Psalms &amp; Proverbs in a Year</string>
     <string name="plan_description_y1ntpspr">
         Courtesy of HEARTLIGHT Internet Magazine,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,9 +193,11 @@ TODO: error and download_document_confirm_prefix need to be parameterized rather
     <string name="rdg_plan_set_start_date">Set Start Date...</string>
     <string name="done">Done</string>
     <string name="reset">Reset</string>
-    <string name="plan_duplicate_user_plan">There is a user reading plan in sdcard
+    <string name="plan_duplicate_user_plan">
+        There is a user reading plan in sdcard
         jsword/readingplan with the same name as an internal plan. It can not be listed here.
-        Please rename the file to something else, leaving it's file extension as .properties</string>
+        Please rename the file to something else, leaving it's file extension as .properties
+    </string>
     <string name="plan_name_y1ntpspr">NT, Psalms &amp; Proverbs in a Year</string>
     <string name="plan_description_y1ntpspr">
         Courtesy of HEARTLIGHT Internet Magazine,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,9 @@ TODO: error and download_document_confirm_prefix need to be parameterized rather
     <string name="rdg_plan_set_start_date">Set Start Date...</string>
     <string name="done">Done</string>
     <string name="reset">Reset</string>
+    <string name="plan_duplicate_user_plan">There is a user reading plan in sdcard
+        jsword/readingplan with the same name as an internal plan. It can not be listed here.
+        Please rename the file to something else but leave it as .properties</string>
     <string name="plan_name_y1ntpspr">NT, Psalms &amp; Proverbs in a Year</string>
     <string name="plan_description_y1ntpspr">
         Courtesy of HEARTLIGHT Internet Magazine,


### PR DESCRIPTION
When user adds custom reading plan with same name as an internal plan, do not show it in plan list AND also show a message notifying user to rename the file in order to use it.