### PR TITLE
Reading Plan changes, improvements

### DIFF
--- a/app/src/main/java/net/bible/android/control/readingplan/HistoricReadingStatus.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/HistoricReadingStatus.kt
@@ -18,6 +18,8 @@
 
 package net.bible.android.control.readingplan
 
+import net.bible.service.readingplan.ReadingPlanInfoDto
+
 /** return isRead' for all historical readings
  *
  * @author Martin Denham [mjdenham at gmail dot com]
@@ -37,7 +39,7 @@ class HistoricReadingStatus(planCode: String, day: Int, numReadings: Int) : Read
         return true
     }
 
-    override fun delete() {
+    override fun delete(planInfo: ReadingPlanInfoDto) {
         // do nothing
     }
 

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -56,7 +56,6 @@ class ReadingPlanControl @Inject constructor(
 {
 
     private val readingPlanDao = ReadingPlanDao()
-    private val rAdapter = ReadingPlanDbAdapter.instance
     private var readingStatus: ReadingStatus? = null
 
     /** allow front end to determine if a plan needs has been selected
@@ -102,14 +101,15 @@ class ReadingPlanControl @Inject constructor(
                     it.readingDate == todayDate.time
                 }?.day ?: 1
             } else {
-                rAdapter.getReadingCurrentDay(planCode)
+                readingPlanDao.getReadingPlanInfoDto(planCode)
+                    .rAdapter.getReadingCurrentDay(planCode)
             }
         }
         private set(day) {
             val planCode = currentPlanCode
             if (readingPlanDao.getReading(planCode, 1).isDateBasedPlan) return
-
-            rAdapter.setReadingCurrentDay(planCode, day)
+            readingPlanDao.getReadingPlanInfoDto(planCode)
+                .rAdapter.setReadingCurrentDay(planCode, day)
         }
 
     val shortTitle: String
@@ -175,7 +175,7 @@ class ReadingPlanControl @Inject constructor(
             } else {
                 ReadingStatus(planCode, day, oneDaysReadingsDto.numReadings)
             }
-			this.readingStatus = readingStatus
+			this.readingStatus = readingStatus.apply { reloadStatus() }
         }
         return readingStatus
     }
@@ -332,7 +332,7 @@ class ReadingPlanControl @Inject constructor(
             prefsEditor.apply()
         }
 
-        rAdapter.resetPlan(plan.planCode)
+        plan.rAdapter.resetPlan(plan.planCode)
     }
 
     private fun convertReadingVersification(readingKey: Key, bibleToBeUsed: AbstractPassageBook): List<Key> {

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -28,6 +28,7 @@ import net.bible.android.control.page.window.ActiveWindowPageManagerProvider
 import net.bible.android.control.speak.SpeakControl
 import net.bible.android.control.versification.VersificationConverter
 import net.bible.service.common.CommonUtils
+import net.bible.service.db.readingplan.ReadingPlanDbAdapter
 import net.bible.service.readingplan.OneDaysReadingsDto
 import net.bible.service.readingplan.ReadingPlanDao
 import net.bible.service.readingplan.ReadingPlanInfoDto
@@ -55,7 +56,7 @@ class ReadingPlanControl @Inject constructor(
 {
 
     private val readingPlanDao = ReadingPlanDao()
-
+    private val rAdapter = ReadingPlanDbAdapter.instance
     private var readingStatus: ReadingStatus? = null
 
     /** allow front end to determine if a plan needs has been selected
@@ -325,23 +326,17 @@ class ReadingPlanControl @Inject constructor(
         }
     }
 
-    /** User has chosen to start a plan
-     */
     fun reset(plan: ReadingPlanInfoDto) {
-        plan.reset()
-
         val prefs = CommonUtils.sharedPreferences
         val prefsEditor = prefs.edit()
 
         // if resetting default plan then remove default
         if (plan.planCode == currentPlanCode) {
             prefsEditor.remove(READING_PLAN)
+            prefsEditor.apply()
         }
 
-        prefsEditor.remove(plan.code + ReadingPlanInfoDto.READING_PLAN_START_EXT)
-        prefsEditor.remove(plan.code + READING_PLAN_DAY_EXT)
-
-        prefsEditor.apply()
+        rAdapter.resetPlan(plan.planCode)
     }
 
     private fun convertReadingVersification(readingKey: Key, bibleToBeUsed: AbstractPassageBook): List<Key> {
@@ -358,7 +353,6 @@ class ReadingPlanControl @Inject constructor(
     companion object {
 
         private const val READING_PLAN = "reading_plan"
-        private const val READING_PLAN_DAY_EXT = "_day"
 
         private const val TAG = "ReadingPlanControl"
     }

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -92,7 +92,6 @@ class ReadingPlanControl @Inject constructor(
     var currentPlanDay: Int
         get() {
             val planCode = currentPlanCode
-            val prefs = CommonUtils.sharedPreferences
             return if (readingPlanDao.getReading(planCode, 1).isDateBasedPlan) {
                 val todayDate = Calendar.getInstance()
                 todayDate.set(Calendar.HOUR_OF_DAY, 0)
@@ -103,17 +102,14 @@ class ReadingPlanControl @Inject constructor(
                     it.readingDate == todayDate.time
                 }?.day ?: 1
             } else {
-                prefs.getInt(planCode + READING_PLAN_DAY_EXT, 1)
+                rAdapter.getReadingCurrentDay(planCode)
             }
         }
         private set(day) {
             val planCode = currentPlanCode
             if (readingPlanDao.getReading(planCode, 1).isDateBasedPlan) return
 
-            val prefs = CommonUtils.sharedPreferences
-            prefs.edit()
-                    .putInt(planCode + READING_PLAN_DAY_EXT, day)
-                    .apply()
+            rAdapter.setReadingCurrentDay(planCode, day)
         }
 
     val shortTitle: String

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -140,7 +140,7 @@ class ReadingPlanControl @Inject constructor(
      */
     fun startReadingPlan(plan: ReadingPlanInfoDto) {
         // set default plan
-        setReadingPlan(plan.code)
+        setReadingPlan(plan.planCode)
 
         // tell the plan to set a start date
         plan.start()
@@ -334,7 +334,7 @@ class ReadingPlanControl @Inject constructor(
         val prefsEditor = prefs.edit()
 
         // if resetting default plan then remove default
-        if (plan.code == currentPlanCode) {
+        if (plan.planCode == currentPlanCode) {
             prefsEditor.remove(READING_PLAN)
         }
 

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -174,9 +174,9 @@ class ReadingPlanControl @Inject constructor(
             val oneDaysReadingsDto = readingPlanDao.getReading(planCode, day)
             // if Historic then return historic status that returns read=true for all passages
             readingStatus = if (!oneDaysReadingsDto.isDateBasedPlan && day < currentPlanDay) {
-                HistoricReadingStatus(currentPlanCode, day, oneDaysReadingsDto.numReadings)
+                HistoricReadingStatus(planCode, day, oneDaysReadingsDto.numReadings)
             } else {
-                ReadingStatus(currentPlanCode, day, oneDaysReadingsDto.numReadings)
+                ReadingStatus(planCode, day, oneDaysReadingsDto.numReadings)
             }
 			this.readingStatus = readingStatus
         }

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -41,7 +41,6 @@ import java.util.Calendar
 import java.util.Date
 
 import javax.inject.Inject
-import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
 
@@ -174,7 +173,7 @@ class ReadingPlanControl @Inject constructor(
                 readingStatus.day != day) {
             val oneDaysReadingsDto = readingPlanDao.getReading(planCode, day)
             // if Historic then return historic status that returns read=true for all passages
-            readingStatus = if (day < currentPlanDay) {
+            readingStatus = if (!oneDaysReadingsDto.isDateBasedPlan && day < currentPlanDay) {
                 HistoricReadingStatus(currentPlanCode, day, oneDaysReadingsDto.numReadings)
             } else {
                 ReadingStatus(currentPlanCode, day, oneDaysReadingsDto.numReadings)

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -215,7 +215,7 @@ class ReadingPlanControl @Inject constructor(
         // was this the next reading plan day due whether on schedule or not
         if (currentPlanDay == day) {
             // do not leave prefs for historic days - we show all historic readings as 'read'
-            getReadingStatus(day).delete()
+            getReadingStatus(day).delete(planInfo)
 
             // was this the last day in the plan
             if (readingPlanDao.getNumberOfPlanDays(currentPlanCode) == day) {

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingPlanControl.kt
@@ -28,7 +28,6 @@ import net.bible.android.control.page.window.ActiveWindowPageManagerProvider
 import net.bible.android.control.speak.SpeakControl
 import net.bible.android.control.versification.VersificationConverter
 import net.bible.service.common.CommonUtils
-import net.bible.service.db.readingplan.ReadingPlanDbAdapter
 import net.bible.service.readingplan.OneDaysReadingsDto
 import net.bible.service.readingplan.ReadingPlanDao
 import net.bible.service.readingplan.ReadingPlanInfoDto

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingStatus.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingStatus.kt
@@ -18,10 +18,10 @@
 
 package net.bible.android.control.readingplan
 
-import java.util.BitSet
-
-import net.bible.service.common.CommonUtils
-import android.content.SharedPreferences
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
+import net.bible.service.db.readingplan.ReadingPlanDbAdapter
 
 /**
  * @author Martin Denham [mjdenham at gmail dot com]
@@ -31,8 +31,28 @@ open class ReadingStatus(
 		val day: Int,
 		private val numReadings: Int) {
 
-    // there won't be any more than 10 readings per day in any plan
-    private val status = BitSet(4)
+    companion object {
+        val rAdapter = ReadingPlanDbAdapter.instance
+    }
+
+    @Serializable
+    private data class ChapterRead(val readingNumber: Int,
+                           var isRead: Boolean = false)
+    @Serializable
+    private data class ReadingStatus(var chapterReadArray: ArrayList<ChapterRead>) {
+        constructor(statusString: String) : this(toArrayList(statusString))
+        companion object {
+            private fun toArrayList(readingStatus: String): ArrayList<ChapterRead> {
+                return Json(JsonConfiguration(strictMode = false)).parse(serializer(), readingStatus).chapterReadArray
+            }
+        }
+
+        override fun toString(): String {
+            return Json.stringify(serializer(), this)
+        }
+    }
+
+    private var status = ReadingStatus(ArrayList())
     val isAllRead: Boolean
         get() {
             for (i in 0 until numReadings) {
@@ -43,79 +63,53 @@ open class ReadingStatus(
             return true
         }
 
-    private val prefsKey: String
-        get() = planCode + "_" + day
-
     init {
         reloadStatus()
     }
 
     open fun setRead(readingNo: Int) {
-        status.set(readingNo)
-        saveStatus()
+        setStatus(readingNo, true)
     }
 
     open fun setUnread(readingNo: Int) {
-        status.set(readingNo, false)
+        setStatus(readingNo, false)
+    }
+
+    private fun setStatus(readingNo: Int, read: Boolean) {
+        val chapterRead = status.chapterReadArray.find { it.readingNumber == readingNo }
+        if (chapterRead == null) {
+            status.chapterReadArray.add(ChapterRead(readingNo, read))
+        } else {
+            chapterRead.isRead = read
+            status.chapterReadArray.add(chapterRead)
+        }
+        status.chapterReadArray.sortBy { it.readingNumber }
+
         saveStatus()
     }
 
     open fun isRead(readingNo: Int): Boolean {
-        return status.get(readingNo)
+        return status.chapterReadArray.find { it.readingNumber == readingNo }?.isRead ?: false
     }
 
     fun setAllRead() {
         for (i in 0 until numReadings) {
             setRead(i)
         }
-        saveStatus()
     }
 
     /** do not leave prefs around for historic days
      */
     open fun delete() {
-        val prefs = CommonUtils.sharedPreferences
-        if (prefs.contains(prefsKey)) {
-            prefs.edit()
-                    .remove(prefsKey)
-                    .commit()
-        }
+        // do nothing for now
     }
 
-    /** read status from prefs string
-     */
     open fun reloadStatus() {
-        val prefs = CommonUtils.sharedPreferences
-        val gotStatus = prefs.getString(prefsKey, "")
-        for (i in 0 until gotStatus!!.length) {
-            if (gotStatus[i] == ONE) {
-                status.set(i)
-            } else {
-                status.clear(i)
-            }
-        }
+        val status: String? = rAdapter.getReadingPlanStatus(planCode, day)
+        status?.let { this.status = ReadingStatus(status) }
     }
 
-    /** serialize read status to prefs in a string
-     */
     private fun saveStatus() {
-        val strStatus = StringBuffer()
-        for (i in 0 until status.length()) {
-            if (status.get(i)) {
-                strStatus.append(ONE)
-            } else {
-                strStatus.append(ZERO)
-            }
-        }
-        val prefs = CommonUtils.sharedPreferences
-        prefs.edit()
-                .putString(prefsKey, strStatus.toString())
-                .commit()
+        rAdapter.setReadingPlanStatus(planCode, day, status.toString())
     }
-
-    companion object {
-        private val ONE = '1'
-        private val ZERO = '0'
-    }
-
 }

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingStatus.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingStatus.kt
@@ -18,6 +18,7 @@
 
 package net.bible.android.control.readingplan
 
+import kotlinx.serialization.PrimitiveKind
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
@@ -31,9 +32,7 @@ open class ReadingStatus(
 		val day: Int,
 		private val numReadings: Int) {
 
-    companion object {
-        val rAdapter = ReadingPlanDbAdapter.instance
-    }
+    private val rAdapter: ReadingPlanDbAdapter get() { return ReadingPlanDbAdapter.instance }
 
     @Serializable
     private data class ChapterRead(val readingNumber: Int,
@@ -55,17 +54,13 @@ open class ReadingStatus(
     private var status = ReadingStatus(ArrayList())
     val isAllRead: Boolean
         get() {
-            for (i in 0 until numReadings) {
+            for (i in 1..numReadings) {
                 if (!isRead(i)) {
                     return false
                 }
             }
             return true
         }
-
-    init {
-        reloadStatus()
-    }
 
     open fun setRead(readingNo: Int) {
         setStatus(readingNo, true)
@@ -75,7 +70,7 @@ open class ReadingStatus(
         setStatus(readingNo, false)
     }
 
-    private fun setStatus(readingNo: Int, read: Boolean) {
+    fun setStatus(readingNo: Int, read: Boolean, saveStatus: Boolean = true) {
         val chapterRead = status.chapterReadArray.find { it.readingNumber == readingNo }
         if (chapterRead == null) {
             status.chapterReadArray.add(ChapterRead(readingNo, read))
@@ -85,7 +80,7 @@ open class ReadingStatus(
         }
         status.chapterReadArray.sortBy { it.readingNumber }
 
-        saveStatus()
+        if (saveStatus) saveStatus()
     }
 
     open fun isRead(readingNo: Int): Boolean {
@@ -93,7 +88,7 @@ open class ReadingStatus(
     }
 
     fun setAllRead() {
-        for (i in 0 until numReadings) {
+        for (i in 1..numReadings) {
             setRead(i)
         }
     }
@@ -111,5 +106,9 @@ open class ReadingStatus(
 
     private fun saveStatus() {
         rAdapter.setReadingPlanStatus(planCode, day, status.toString())
+    }
+
+    override fun toString(): String {
+        return status.toString()
     }
 }

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingStatus.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingStatus.kt
@@ -18,12 +18,10 @@
 
 package net.bible.android.control.readingplan
 
-import kotlinx.serialization.PrimitiveKind
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
 import net.bible.service.db.readingplan.ReadingPlanDbAdapter
-import net.bible.service.readingplan.OneDaysReadingsDto
 import net.bible.service.readingplan.ReadingPlanInfoDto
 
 /**

--- a/app/src/main/java/net/bible/android/control/readingplan/ReadingStatus.kt
+++ b/app/src/main/java/net/bible/android/control/readingplan/ReadingStatus.kt
@@ -23,6 +23,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
 import net.bible.service.db.readingplan.ReadingPlanDbAdapter
+import net.bible.service.readingplan.OneDaysReadingsDto
+import net.bible.service.readingplan.ReadingPlanInfoDto
 
 /**
  * @author Martin Denham [mjdenham at gmail dot com]
@@ -95,8 +97,8 @@ open class ReadingStatus(
 
     /** do not leave prefs around for historic days
      */
-    open fun delete() {
-        // do nothing for now
+    open fun delete(planInfo: ReadingPlanInfoDto) {
+        rAdapter.deleteOldStatuses(planInfo, day)
     }
 
     open fun reloadStatus() {

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
@@ -243,7 +243,7 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
     override fun getIntentForHistoryList(): Intent {
         val intent = intent
 
-        intent.putExtra(DailyReading.PLAN, mReadings.readingPlanInfo.code)
+        intent.putExtra(DailyReading.PLAN, mReadings.readingPlanInfo.planCode)
         intent.putExtra(DailyReading.DAY, mReadings.day)
 
         return intent

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
@@ -190,7 +190,7 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
      */
     fun onSpeakAll(view: View?) {
         Log.i(TAG, "Speak all")
-        readingPlanControl.speak(mDay, mReadings.readingKeys)
+        readingPlanControl.speak(mDay, mReadings.getReadingKeys)
 
         updateTicksAndDone()
     }

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
@@ -99,7 +99,7 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
             BookName.setFullBookName(!CommonUtils.isPortrait)
 
             val layout = findViewById<View>(R.id.reading_container) as TableLayout
-            for (i in 0 until mReadings.numReadings) {
+            for (i in 1..mReadings.numReadings) {
                 val child = layoutInflater.inflate(R.layout.reading_plan_one_reading, null)
 
                 // Ticks
@@ -129,7 +129,7 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
                 val speakBtn = child.findViewById<View>(R.id.speakButton) as Button
                 speakBtn.setOnClickListener { onSpeak(i) }
 
-                layout.addView(child, i)
+                layout.addView(child, i-1)
             }
 
             // restore full book name setting
@@ -272,7 +272,7 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
 
         for (i in mImageTickList.indices) {
             val imageTick = mImageTickList[i]
-            if (status.isRead(i)) {
+            if (status.isRead(i+1)) {
                 imageTick.setImageResource(R.drawable.btn_check_buttonless_on)
             } else {
                 imageTick.setImageResource(R.drawable.btn_check_buttonless_off)

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
@@ -325,8 +325,11 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
 
             }
             R.id.reset -> {
-                readingPlanControl.reset(mReadings.readingPlanInfo)
-                finish()
+                Dialogs.getInstance().showMsg(R.string.reset_plan_question, true)
+                {
+                    readingPlanControl.reset(mReadings.readingPlanInfo)
+                    finish()
+                }
                 isHandled = true
             }
             R.id.setStartDate -> {

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
@@ -168,7 +168,7 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
 
     /** user pressed read button by 1 reading
      */
-    fun onRead(readingNo: Int) {
+    private fun onRead(readingNo: Int) {
         Log.i(TAG, "Read $readingNo")
         val readingKey = mReadings.getReadingKey(readingNo)
         readingPlanControl.read(mDay, readingNo, readingKey)
@@ -178,7 +178,7 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
 
     /** user pressed speak button by 1 reading
      */
-    fun onSpeak(readingNo: Int) {
+    private fun onSpeak(readingNo: Int) {
         Log.i(TAG, "Speak $readingNo")
         val readingKey = mReadings.getReadingKey(readingNo)
         readingPlanControl.speak(mDay, readingNo, readingKey)
@@ -188,7 +188,7 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
 
     /** user pressed speak button by All
      */
-    fun onSpeakAll(view: View?) {
+    private fun onSpeakAll(view: View?) {
         Log.i(TAG, "Speak all")
         readingPlanControl.speak(mDay, mReadings.getReadingKeys)
 
@@ -243,8 +243,8 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
     override fun getIntentForHistoryList(): Intent {
         val intent = intent
 
-        intent.putExtra(DailyReading.PLAN, mReadings.readingPlanInfo.planCode)
-        intent.putExtra(DailyReading.DAY, mReadings.day)
+        intent.putExtra(PLAN, mReadings.readingPlanInfo.planCode)
+        intent.putExtra(DAY, mReadings.day)
 
         return intent
     }

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReadingItemAdapter.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReadingItemAdapter.kt
@@ -25,6 +25,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.TwoLineListItem
+import java.text.SimpleDateFormat
 
 /**
  * Retain similar style to TwoLineListView but for single TextView on each line
@@ -46,16 +47,20 @@ class DailyReadingItemAdapter(_context: Context, private val resource: Int, _ite
         } else {
             view = convertView as TwoLineListItem
         }
+        item ?: return view
 
         // Set value for the first text field
         if (view.text1 != null) {
-            val line1 = item!!.dayDesc
-            view.text1.text = line1
+            view.text1.text = if (item.isDateBasedPlan) {
+                SimpleDateFormat.getDateInstance().format(item.readingDate)
+            } else {
+                item.dayDesc
+            }
         }
 
         // set value for the second text field
         if (view.text2 != null) {
-            val line2 = item!!.readingsDesc
+            val line2 = item.readingsDesc
             view.text2.text = line2
         }
 

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReadingItemAdapter.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReadingItemAdapter.kt
@@ -41,11 +41,11 @@ class DailyReadingItemAdapter(_context: Context, private val resource: Int, _ite
 
         // Pick up the TwoLineListItem defined in the xml file
         val view: TwoLineListItem
-        if (convertView == null) {
+        view = if (convertView == null) {
             val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-            view = inflater.inflate(resource, parent, false) as TwoLineListItem
+            inflater.inflate(resource, parent, false) as TwoLineListItem
         } else {
-            view = convertView as TwoLineListItem
+            convertView as TwoLineListItem
         }
         item ?: return view
 

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
@@ -102,7 +102,7 @@ class ReadingPlanSelectorList : ListActivityBase() {
         super.onContextItemSelected(item)
         val menuInfo = item.menuInfo as AdapterContextMenuInfo
         val plan = mReadingPlanList[menuInfo.position]
-        Log.d(TAG, "Selected " + plan.code)
+        Log.d(TAG, "Selected " + plan.planCode)
 		when (item.itemId) {
 			R.id.reset -> {
 				readingPlanControl.reset(plan)

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
@@ -113,8 +113,8 @@ class ReadingPlanSelectorList : ListActivityBase() {
     }
 
     companion object {
-        private val TAG = "ReadingPlanList"
+        private const val TAG = "ReadingPlanList"
 
-        private val LIST_ITEM_TYPE = android.R.layout.simple_list_item_2
+        private const val LIST_ITEM_TYPE = android.R.layout.simple_list_item_2
     }
 }

--- a/app/src/main/java/net/bible/service/db/CommonDatabaseHelper.java
+++ b/app/src/main/java/net/bible/service/db/CommonDatabaseHelper.java
@@ -28,6 +28,7 @@ import android.util.Log;
 import net.bible.android.BibleApplication;
 import net.bible.service.db.bookmark.BookmarkDatabaseDefinition;
 import net.bible.service.db.mynote.MyNoteDatabaseDefinition;
+import net.bible.service.db.readingplan.ReadingPlanDatabaseOperations;
 
 /**
  * Oversee database creation and upgrade based on version
@@ -37,7 +38,7 @@ import net.bible.service.db.mynote.MyNoteDatabaseDefinition;
  */
 public class CommonDatabaseHelper extends SQLiteOpenHelper {
 	private static final String TAG = "CommonDatabaseHelper";
-	static final int DATABASE_VERSION = 5;
+	static final int DATABASE_VERSION = 6;
 	public static final String DATABASE_NAME = "andBibleDatabase.db";
 
 	private static CommonDatabaseHelper sSingleton = null;
@@ -101,6 +102,10 @@ public class CommonDatabaseHelper extends SQLiteOpenHelper {
 			}
 			if (oldVersion == 4) {
 				BookmarkDatabaseDefinition.getInstance().upgradeToVersion5(db);
+				oldVersion += 1;
+			}
+			if (oldVersion == 5) {
+				ReadingPlanDatabaseOperations.Companion.getInstance().onCreate(db);
 				oldVersion += 1;
 			}
 		} catch (SQLiteException e) {

--- a/app/src/main/java/net/bible/service/db/CommonDatabaseHelper.java
+++ b/app/src/main/java/net/bible/service/db/CommonDatabaseHelper.java
@@ -77,6 +77,7 @@ public class CommonDatabaseHelper extends SQLiteOpenHelper {
 	public void onCreate(SQLiteDatabase db) {
 		BookmarkDatabaseDefinition.getInstance().onCreate(db);
 		MyNoteDatabaseDefinition.getInstance().onCreate(db);
+		ReadingPlanDatabaseOperations.Companion.getInstance().onCreate(db);
 	}
 	
 	@Override

--- a/app/src/main/java/net/bible/service/db/CommonDatabaseHelper.java
+++ b/app/src/main/java/net/bible/service/db/CommonDatabaseHelper.java
@@ -107,6 +107,7 @@ public class CommonDatabaseHelper extends SQLiteOpenHelper {
 			}
 			if (oldVersion == 5) {
 				ReadingPlanDatabaseOperations.Companion.getInstance().onCreate(db);
+				ReadingPlanDatabaseOperations.Companion.getInstance().importPrefsToDatabase(db);
 				oldVersion += 1;
 			}
 		} catch (SQLiteException e) {

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
@@ -49,7 +49,7 @@ class ReadingPlanDatabaseOperations {
                 $COLUMN_ID INTEGER PRIMARY KEY AUTOINCREMENT,
                 $COLUMN_PLAN_CODE TEXT NOT NULL,
                 $COLUMN_PLAN_DAY INTEGER NOT NULL,
-                $COLUMN_READING_STATUS TEXT
+                $COLUMN_READING_STATUS TEXT NOT NULL
             );
             CREATE INDEX code_day ON $TABLE_NAME($COLUMN_PLAN_CODE,$COLUMN_PLAN_DAY);
         """

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
@@ -27,6 +27,18 @@ import java.lang.Exception
  */
 object ReadingPlanDatabaseDefinition {
 
+    /** Table to keep track of plan start date and current day progress
+     */
+    object ReadingPlan : BaseColumns {
+        const val TABLE_NAME = "readingplan"
+        const val COLUMN_ID = BaseColumns._ID
+        const val COLUMN_PLAN_CODE = "plan_code"
+        const val COLUMN_PLAN_START_DATE = "plan_start_date"
+        const val COLUMN_PLAN_CURRENT_DAY = "plan_current_day"
+    }
+
+    /** Table to keep track of which chapters have been read
+     */
     object ReadingPlanStatus : BaseColumns {
         const val TABLE_NAME = "readingplan_status"
         const val COLUMN_ID = BaseColumns._ID
@@ -42,6 +54,19 @@ class ReadingPlanDatabaseOperations {
     }
 
     private val TAG = "ReadingPlanDbOps"
+
+    private val readingPlan = ReadingPlanDatabaseDefinition.ReadingPlan
+    private val SQL_CREATE_READING_PLAN = readingPlan.run {
+        """
+            CREATE TABLE $TABLE_NAME (
+                $COLUMN_ID INTEGER PRIMARY KEY AUTOINCREMENT,
+                $COLUMN_PLAN_CODE TEXT NOT NULL,
+                $COLUMN_PLAN_START_DATE INTEGER NOT NULL,
+                $COLUMN_PLAN_CURRENT_DAY INTEGER NOT NULL DEFAULT 1
+            );
+        """
+    }
+
     private val readingPlanStatus = ReadingPlanDatabaseDefinition.ReadingPlanStatus
     private val SQL_CREATE_READING_PLAN_STATUS = readingPlanStatus.run {
         """
@@ -56,8 +81,16 @@ class ReadingPlanDatabaseOperations {
     }
 
     fun onCreate(db: SQLiteDatabase) {
-        Log.i(TAG, "Creating table ${readingPlanStatus.TABLE_NAME}")
+
         try {
+            Log.i(TAG, "Creating table ${readingPlan.TABLE_NAME}")
+            db.execSQL(SQL_CREATE_READING_PLAN)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error creating table ${readingPlan.TABLE_NAME}")
+        }
+
+        try {
+            Log.i(TAG, "Creating table ${readingPlanStatus.TABLE_NAME}")
             db.execSQL(SQL_CREATE_READING_PLAN_STATUS)
         } catch (e: Exception) {
             Log.e(TAG, "Error creating table ${readingPlanStatus.TABLE_NAME}")

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 Martin Denham, Tuomas Airaksinen and the And Bible contributors.
+ *
+ * This file is part of And Bible (http://github.com/AndBible/and-bible).
+ *
+ * And Bible is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * And Bible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with And Bible.
+ * If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+package net.bible.service.db.readingplan
+
+import android.database.sqlite.SQLiteDatabase
+import android.provider.BaseColumns
+import android.util.Log
+import java.lang.Exception
+
+/** @author Timmy Braun [tim.bze at gmail dot com] (Oct. 21, 2019)
+ */
+object ReadingPlanDatabaseDefinition {
+
+    object ReadingPlanStatus : BaseColumns {
+        const val TABLE_NAME = "readingplan_status"
+        const val COLUMN_ID = BaseColumns._ID
+        const val COLUMN_PLAN_CODE = "plan_code"
+        const val COLUMN_PLAN_DAY = "plan_day"
+        const val COLUMN_READING_STATUS = "reading_status"
+    }
+}
+
+class ReadingPlanDatabaseOperations {
+    companion object {
+        val instance = ReadingPlanDatabaseOperations()
+    }
+
+    private val TAG = "ReadingPlanDbOps"
+    private val readingPlanStatus = ReadingPlanDatabaseDefinition.ReadingPlanStatus
+    private val SQL_CREATE_READING_PLAN_STATUS = readingPlanStatus.run {
+        """
+            CREATE TABLE $TABLE_NAME (
+                $COLUMN_ID INTEGER PRIMARY KEY AUTOINCREMENT,
+                $COLUMN_PLAN_CODE TEXT NOT NULL,
+                $COLUMN_PLAN_DAY INTEGER NOT NULL,
+                $COLUMN_READING_STATUS TEXT
+            );
+            CREATE INDEX code_day ON $TABLE_NAME($COLUMN_PLAN_CODE,$COLUMN_PLAN_DAY);
+        """
+    }
+
+    fun onCreate(db: SQLiteDatabase) {
+        Log.i(TAG, "Creating table ${readingPlanStatus.TABLE_NAME}")
+        try {
+            db.execSQL(SQL_CREATE_READING_PLAN_STATUS)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error creating table ${readingPlanStatus.TABLE_NAME}")
+        }
+    }
+}

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
@@ -145,7 +145,7 @@ class ReadingPlanDatabaseOperations {
 
             // find other days that have reading status in shared preferences
             for ((key, value) in prefs.all) {
-                if (key.contains(".*_[0-9]*$".toRegex()) && value.toString().contains("^[0-1]*$".toRegex())) {
+                if (key.contains((planCode + "_[0-9]{1,3}$").toRegex()) && value.toString().contains("^[0-1]*$".toRegex())) {
                     val day = "(?<=_)[0-9]*\$".toRegex().find(key).toString().toIntOrNull()
                     day ?: continue
                     enterStatusToDb(value.toString(), planCode, day, db)

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDatabaseDefinition.kt
@@ -146,7 +146,7 @@ class ReadingPlanDatabaseOperations {
             // find other days that have reading status in shared preferences
             for ((key, value) in prefs.all) {
                 if (key.contains((planCode + "_[0-9]{1,3}$").toRegex()) && value.toString().contains("^[0-1]*$".toRegex())) {
-                    val day = "(?<=_)[0-9]*\$".toRegex().find(key).toString().toIntOrNull()
+                    val day = "(?<=_)[0-9]{1,3}$".toRegex().find(key)?.value?.toIntOrNull()
                     day ?: continue
                     enterStatusToDb(value.toString(), planCode, day, db)
 

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
@@ -97,4 +97,15 @@ class ReadingPlanDbAdapter {
         }
     }
 
+    fun resetPlan(planCode: String) {
+        // delete reading statuses
+        db.delete(statusDef.TABLE_NAME,
+            "${statusDef.COLUMN_PLAN_CODE}=?",
+            arrayOf(planCode))
+
+        // delete reading start date and current day
+        db.delete(readingPlanDef.TABLE_NAME,
+            "${readingPlanDef.COLUMN_PLAN_CODE}=?",
+            arrayOf(planCode))
+    }
 }

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
@@ -95,7 +95,9 @@ class ReadingPlanDbAdapter {
 
         if (rows < 1) {
             values.put(readingPlanDef.COLUMN_PLAN_CODE, planCode)
-            db.insert(readingPlanDef.TABLE_NAME,null, values)
+            if (db.insert(readingPlanDef.TABLE_NAME,null, values) < 0) {
+                Log.e(TAG, "Error occurred while trying to insert startDate $startDate into db for plan $planCode")
+            }
         }
     }
 
@@ -134,6 +136,7 @@ class ReadingPlanDbAdapter {
     }
 
     fun resetPlan(planCode: String) {
+        Log.i(TAG, "Now resetting plan $planCode in database. Removing start date, current day, and read statuses")
         // delete reading statuses
         db.delete(statusDef.TABLE_NAME,
             "${statusDef.COLUMN_PLAN_CODE}=?",

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019 Martin Denham, Tuomas Airaksinen and the And Bible contributors.
+ *
+ * This file is part of And Bible (http://github.com/AndBible/and-bible).
+ *
+ * And Bible is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * And Bible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with And Bible.
+ * If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+package net.bible.service.db.readingplan
+
+import android.content.ContentValues
+import android.util.Log
+import net.bible.service.db.CommonDatabaseHelper
+
+/** @author Timmy Braun [tim.bze at gmail dot com] (Oct. 22, 2019)
+ */
+class ReadingPlanDbAdapter {
+    companion object {
+        val instance = ReadingPlanDbAdapter()
+
+        private const val TAG = "ReadingPlanDBAdapter"
+    }
+
+    private val db = CommonDatabaseHelper.getInstance().readableDatabase
+    private val statusDef = ReadingPlanDatabaseDefinition.ReadingPlanStatus
+
+    fun getReadingPlanStatus(planCode: String, dayNo: Int): String? {
+        val selection = "${statusDef.COLUMN_PLAN_CODE}=? AND ${statusDef.COLUMN_PLAN_DAY}=?"
+        val selectionArgs = arrayOf(planCode, dayNo.toString())
+        val q = db.query(statusDef.TABLE_NAME,
+            arrayOf(statusDef.COLUMN_READING_STATUS),
+            selection,
+            selectionArgs,
+            null, null, null)
+        if (q.moveToFirst()) return q.getString(0)
+        return null
+    }
+
+    fun setReadingPlanStatus(planCode: String, dayNo: Int, status: String) {
+        if (db.update(statusDef.TABLE_NAME,
+                ContentValues().apply {
+                    put(statusDef.COLUMN_READING_STATUS, status)
+                },
+                "${statusDef.COLUMN_PLAN_CODE}=? AND ${statusDef.COLUMN_PLAN_DAY}=?",
+                arrayOf(planCode, dayNo.toString())
+            ) < 1) {
+            // if no row updated then insert new row
+
+            if (db.insert(statusDef.TABLE_NAME,
+                    null,
+                    ContentValues().apply {
+                        put(statusDef.COLUMN_PLAN_CODE, planCode)
+                        put(statusDef.COLUMN_PLAN_DAY, dayNo)
+                        put(statusDef.COLUMN_READING_STATUS, status)
+                    }
+                ) < 0) {
+                Log.e(TAG, "Error inserting reading status into table. planCode=$planCode, " +
+                    "dayNo=$dayNo, status=$status")
+            }
+        }
+    }
+}

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
@@ -21,6 +21,8 @@ package net.bible.service.db.readingplan
 import android.content.ContentValues
 import android.util.Log
 import net.bible.service.db.CommonDatabaseHelper
+import java.lang.Exception
+import kotlin.math.max
 
 /** @author Timmy Braun [tim.bze at gmail dot com] (Oct. 22, 2019)
  */
@@ -94,6 +96,40 @@ class ReadingPlanDbAdapter {
         if (rows < 1) {
             values.put(readingPlanDef.COLUMN_PLAN_CODE, planCode)
             db.insert(readingPlanDef.TABLE_NAME,null, values)
+        }
+    }
+
+    fun getReadingCurrentDay(planCode: String): Int {
+        val selection = "${readingPlanDef.COLUMN_PLAN_CODE}=?"
+        val selectionArgs = arrayOf(planCode)
+        var currentDay = 0
+        val q = db.query(readingPlanDef.TABLE_NAME,
+            arrayOf(readingPlanDef.COLUMN_PLAN_CURRENT_DAY),
+            selection,
+            selectionArgs,
+            null, null, null)
+        if (q.moveToFirst()) currentDay = q.getInt(0)
+        return max(1, currentDay)
+    }
+
+    fun setReadingCurrentDay(planCode: String, dayNo: Int) {
+        val values = ContentValues()
+        values.put(readingPlanDef.COLUMN_PLAN_CURRENT_DAY, dayNo)
+        var rows: Int = 0
+        try {
+            rows = db.update(readingPlanDef.TABLE_NAME,
+                values,
+                "${readingPlanDef.COLUMN_PLAN_CODE}=?",
+                arrayOf(planCode))
+        } catch (e: Exception) {
+            Log.e(TAG, "Error trying to update db current day $dayNo for plan $planCode", e)
+        }
+
+        if (rows < 1) {
+            values.put(readingPlanDef.COLUMN_PLAN_CODE, planCode)
+            if (db.insert(readingPlanDef.TABLE_NAME,null, values) < 0) {
+                Log.e(TAG, "Error trying to insert db current day $dayNo for plan $planCode")
+            }
         }
     }
 

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
@@ -32,6 +32,7 @@ class ReadingPlanDbAdapter {
     }
 
     private val db = CommonDatabaseHelper.getInstance().readableDatabase
+    private val readingPlanDef = ReadingPlanDatabaseDefinition.ReadingPlan
     private val statusDef = ReadingPlanDatabaseDefinition.ReadingPlanStatus
 
     fun getReadingPlanStatus(planCode: String, dayNo: Int): String? {
@@ -69,4 +70,31 @@ class ReadingPlanDbAdapter {
             }
         }
     }
+
+    fun getReadingStartDate(planCode: String): Long? {
+        val selection = "${readingPlanDef.COLUMN_PLAN_CODE}=?"
+        val selectionArgs = arrayOf(planCode)
+        val q = db.query(readingPlanDef.TABLE_NAME,
+            arrayOf(readingPlanDef.COLUMN_PLAN_START_DATE),
+            selection,
+            selectionArgs,
+            null, null, null)
+        if (q.moveToFirst()) return q.getLong(0)
+        return null
+    }
+
+    fun setReadingStartDate(planCode: String, startDate: Long) {
+        val values = ContentValues()
+        values.put(readingPlanDef.COLUMN_PLAN_START_DATE, startDate)
+        val rows = db.update(readingPlanDef.TABLE_NAME,
+            values,
+            "${readingPlanDef.COLUMN_PLAN_CODE}=?",
+            arrayOf(planCode))
+
+        if (rows < 1) {
+            values.put(readingPlanDef.COLUMN_PLAN_CODE, planCode)
+            db.insert(readingPlanDef.TABLE_NAME,null, values)
+        }
+    }
+
 }

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
@@ -46,8 +46,10 @@ class ReadingPlanDbAdapter {
             selection,
             selectionArgs,
             null, null, null)
-        if (q.moveToFirst()) return q.getString(0)
-        return null
+        var returnValue: String? = null
+        if (q.moveToFirst()) returnValue = q.getString(0)
+        q.close()
+        return returnValue
     }
 
     fun setReadingPlanStatus(planCode: String, dayNo: Int, status: String) {
@@ -82,8 +84,10 @@ class ReadingPlanDbAdapter {
             selection,
             selectionArgs,
             null, null, null)
-        if (q.moveToFirst()) return q.getLong(0)
-        return null
+        var returnValue: Long? = null
+        if (q.moveToFirst()) returnValue = q.getLong(0)
+        q.close()
+        return returnValue
     }
 
     fun setReadingStartDate(planCode: String, startDate: Long) {
@@ -105,14 +109,15 @@ class ReadingPlanDbAdapter {
     fun getReadingCurrentDay(planCode: String): Int {
         val selection = "${readingPlanDef.COLUMN_PLAN_CODE}=?"
         val selectionArgs = arrayOf(planCode)
-        var currentDay = 0
         val q = db.query(readingPlanDef.TABLE_NAME,
             arrayOf(readingPlanDef.COLUMN_PLAN_CURRENT_DAY),
             selection,
             selectionArgs,
             null, null, null)
-        if (q.moveToFirst()) currentDay = q.getInt(0)
-        return max(1, currentDay)
+        var returnValue = 0
+        if (q.moveToFirst()) returnValue = q.getInt(0)
+        q.close()
+        return max(1, returnValue)
     }
 
     fun setReadingCurrentDay(planCode: String, dayNo: Int) {

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
@@ -21,7 +21,6 @@ package net.bible.service.db.readingplan
 import android.content.ContentValues
 import android.util.Log
 import net.bible.service.db.CommonDatabaseHelper
-import net.bible.service.readingplan.OneDaysReadingsDto
 import net.bible.service.readingplan.ReadingPlanInfoDto
 import java.lang.Exception
 import kotlin.math.max
@@ -123,7 +122,7 @@ class ReadingPlanDbAdapter {
     fun setReadingCurrentDay(planCode: String, dayNo: Int) {
         val values = ContentValues()
         values.put(readingPlanDef.COLUMN_PLAN_CURRENT_DAY, dayNo)
-        var rows: Int = 0
+        var rows = 0
         try {
             rows = db.update(readingPlanDef.TABLE_NAME,
                 values,
@@ -142,9 +141,9 @@ class ReadingPlanDbAdapter {
     }
 
     /**
-     * All reading statuses will be deleted that are before the [dayNo] parameter given.
+     * All reading statuses will be deleted that are before the [day] parameter given.
      * Date-based plan statuses are never deleted
-     * @param dayNo The current day, all day statuses before this day will be deleted
+     * @param day The current day, all day statuses before this day will be deleted
      */
     fun deleteOldStatuses(planInfo: ReadingPlanInfoDto, day: Int) {
         if (!planInfo.isDateBasedPlan) {

--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanDbAdapter.kt
@@ -21,6 +21,8 @@ package net.bible.service.db.readingplan
 import android.content.ContentValues
 import android.util.Log
 import net.bible.service.db.CommonDatabaseHelper
+import net.bible.service.readingplan.OneDaysReadingsDto
+import net.bible.service.readingplan.ReadingPlanInfoDto
 import java.lang.Exception
 import kotlin.math.max
 
@@ -29,7 +31,6 @@ import kotlin.math.max
 class ReadingPlanDbAdapter {
     companion object {
         val instance = ReadingPlanDbAdapter()
-
         private const val TAG = "ReadingPlanDBAdapter"
     }
 
@@ -132,6 +133,19 @@ class ReadingPlanDbAdapter {
             if (db.insert(readingPlanDef.TABLE_NAME,null, values) < 0) {
                 Log.e(TAG, "Error trying to insert db current day $dayNo for plan $planCode")
             }
+        }
+    }
+
+    /**
+     * All reading statuses will be deleted that are before the [dayNo] parameter given.
+     * Date-based plan statuses are never deleted
+     * @param dayNo The current day, all day statuses before this day will be deleted
+     */
+    fun deleteOldStatuses(planInfo: ReadingPlanInfoDto, day: Int) {
+        if (!planInfo.isDateBasedPlan) {
+            db.delete(statusDef.TABLE_NAME,
+                "${statusDef.COLUMN_PLAN_CODE}=? AND ${statusDef.COLUMN_PLAN_DAY}<?",
+                arrayOf(planInfo.planCode, day.toString()))
         }
     }
 

--- a/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
+++ b/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
@@ -40,10 +40,14 @@ class OneDaysReadingsDto(val day: Int,
     private var readingKeys: List<Key>? = null
     /** reading date for date-based plan, else null
      */
-    private var readingDate: Date? = null
+    var readingDate: Date? = null
 
     val dayDesc: String get() = BibleApplication.application.getString(R.string.rdg_plan_day, Integer.toString(day))
-    val isDateBasedPlan: Boolean get() = (readingDate != null)
+    val isDateBasedPlan: Boolean
+        get() {
+            checkKeysGenerated()
+            return readingDate != null
+        }
 
     /** get a string representing the date this reading is planned for
      */

--- a/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
+++ b/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
@@ -18,66 +18,75 @@
 
 package net.bible.service.readingplan
 
+import android.annotation.SuppressLint
 import net.bible.android.BibleApplication
 import net.bible.android.activity.R
 
-import org.apache.commons.lang3.StringUtils
 import org.crosswire.jsword.passage.Key
 
 import java.text.SimpleDateFormat
 import java.util.ArrayList
 import java.util.Calendar
+import java.util.Date
 
 /**
  * @author Martin Denham [mjdenham at gmail dot com]
  */
 class OneDaysReadingsDto(val day: Int,
-                         private val mReadings: String?,
+                         private val readingsString: String?,
                          val readingPlanInfo: ReadingPlanInfoDto) :
 		Comparable<OneDaysReadingsDto>
 {
-    private var mReadingKeys: List<Key>? = null
+    private var readingKeys: List<Key>? = null
+    /** reading date for date-based plan, else null
+     */
+    private var readingDate: Date? = null
 
-    val dayDesc: String
-        get() = BibleApplication.application.getString(R.string.rdg_plan_day, Integer.toString(day))
+    val dayDesc: String get() = BibleApplication.application.getString(R.string.rdg_plan_day, Integer.toString(day))
+    val isDateBasedPlan: Boolean get() = (readingDate != null)
 
     /** get a string representing the date this reading is planned for
      */
     val readingDateString: String
         get() {
-            var dateString = ""
-            val startDate = readingPlanInfo.startdate
-            if (startDate != null) {
-                val cal = Calendar.getInstance()
-                cal.time = startDate
-                cal.add(Calendar.DAY_OF_MONTH, day - 1)
-                dateString = SimpleDateFormat.getDateInstance().format(cal.time)
+            checkKeysGenerated()
+            return if (readingDate != null) {
+                SimpleDateFormat.getDateInstance().format(readingDate)
+            } else {
+                var dateString = ""
+                val startDate = readingPlanInfo.startdate
+                if (startDate != null) {
+                    val cal = Calendar.getInstance()
+                    cal.time = startDate
+                    cal.add(Calendar.DAY_OF_MONTH, day - 1)
+                    dateString = SimpleDateFormat.getDateInstance().format(cal.time)
+                }
+                dateString
             }
-            return dateString
         }
 
     val readingsDesc: String
         get() {
             checkKeysGenerated()
             val readingsBldr = StringBuilder()
-            for (i in mReadingKeys!!.indices) {
+            for (i in readingKeys!!.indices) {
                 if (i > 0) {
                     readingsBldr.append(", ")
                 }
-                readingsBldr.append(mReadingKeys!![i].name)
+                readingsBldr.append(readingKeys!![i].name)
             }
             return readingsBldr.toString()
         }
     val numReadings: Int
         get() {
             checkKeysGenerated()
-            return mReadingKeys!!.size
+            return readingKeys!!.size
         }
 
-    val readingKeys: List<Key>
+    val getReadingKeys: List<Key>
         get() {
             checkKeysGenerated()
-            return mReadingKeys!!
+            return readingKeys!!
         }
 
     override fun toString(): String {
@@ -90,23 +99,53 @@ class OneDaysReadingsDto(val day: Int,
 
     fun getReadingKey(no: Int): Key {
         checkKeysGenerated()
-        return mReadingKeys!![no]
+        return readingKeys!![no]
     }
 
     @Synchronized
     private fun checkKeysGenerated() {
-        if (mReadingKeys == null) {
+        if (readingKeys == null) {
             val readingKeyList = ArrayList<Key>()
 
-            if (StringUtils.isNotEmpty(mReadings)) {
+            if (!readingsString.isNullOrEmpty()) {
                 val passageReader = PassageReader(readingPlanInfo.versification!!)
-                val readingArray = mReadings!!.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+
+                val readingArray: Array<String>
+                if (readingsString.contains(';')) {
+                    // date-based reading plan
+                    val dateBasedDay = readingsString.replace(";.*".toRegex(), "") // like Feb-1
+                    readingDate = dateFormatterPlanStringToDate(dateBasedDay)
+                    readingArray = readingsString.replace("^.*;".toRegex(), "")
+                        .split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+                } else {
+                    readingArray = readingsString.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+                }
+
                 for (reading in readingArray) {
                     //use the v11n specified in the reading plan (default is KJV)
                     readingKeyList.add(passageReader.getKey(reading))
                 }
             }
-            mReadingKeys = readingKeyList
+            readingKeys = readingKeyList
         }
+    }
+
+    @SuppressLint("SimpleDateFormat")
+    private val dateBasedFormatMonthDay = SimpleDateFormat("MMM-d")
+    @SuppressLint("SimpleDateFormat")
+    private val dateBasedFormatWithYear = SimpleDateFormat("MMM-d/yyyy")
+
+    /**
+     * @param dateString Must be in this format: Feb-1, Mar-22, Dec-11, etc
+     */
+    private fun dateFormatterPlanStringToDate(dateString: String): Date {
+        return dateBasedFormatWithYear.parse(dateString + "/" + Calendar.getInstance().get(Calendar.YEAR))
+    }
+
+    /**
+     * @return Will return string in this format: Feb-1, Mar-22, Dec-11, etc
+     */
+    private fun dateFormatterPlanDateToString(date: Date): String {
+        return dateBasedFormatMonthDay.format(date).toString()
     }
 }

--- a/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
+++ b/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
@@ -19,7 +19,6 @@
 package net.bible.service.readingplan
 
 import android.annotation.SuppressLint
-import android.util.Log
 import net.bible.android.BibleApplication
 import net.bible.android.activity.R
 
@@ -107,8 +106,11 @@ class OneDaysReadingsDto(val day: Int,
         return day - other.day
     }
 
-    fun getReadingKey(no: Int): Key {
-        return readingKeys!![no]
+    /**
+     * @param readingNo 1-based reading number
+     */
+    fun getReadingKey(readingNo: Int): Key {
+        return readingKeys!![readingNo-1]
     }
 
     @Synchronized

--- a/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
+++ b/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
@@ -19,6 +19,7 @@
 package net.bible.service.readingplan
 
 import android.annotation.SuppressLint
+import android.util.Log
 import net.bible.android.BibleApplication
 import net.bible.android.activity.R
 
@@ -37,15 +38,24 @@ class OneDaysReadingsDto(val day: Int,
                          val readingPlanInfo: ReadingPlanInfoDto) :
 		Comparable<OneDaysReadingsDto>
 {
+
+    @SuppressLint("SimpleDateFormat")
+    private val dateBasedFormatMonthDay = SimpleDateFormat("MMM-d")
+    @SuppressLint("SimpleDateFormat")
+    private val dateBasedFormatWithYear = SimpleDateFormat("MMM-d/yyyy")
+
     private var readingKeys: List<Key>? = null
     /** reading date for date-based plan, else null
      */
     var readingDate: Date? = null
 
+    init {
+        checkKeysGenerated()
+    }
+
     val dayDesc: String get() = BibleApplication.application.getString(R.string.rdg_plan_day, Integer.toString(day))
     val isDateBasedPlan: Boolean
         get() {
-            checkKeysGenerated()
             return readingDate != null
         }
 
@@ -53,7 +63,6 @@ class OneDaysReadingsDto(val day: Int,
      */
     val readingDateString: String
         get() {
-            checkKeysGenerated()
             return if (readingDate != null) {
                 SimpleDateFormat.getDateInstance().format(readingDate)
             } else {
@@ -71,7 +80,6 @@ class OneDaysReadingsDto(val day: Int,
 
     val readingsDesc: String
         get() {
-            checkKeysGenerated()
             val readingsBldr = StringBuilder()
             for (i in readingKeys!!.indices) {
                 if (i > 0) {
@@ -83,13 +91,11 @@ class OneDaysReadingsDto(val day: Int,
         }
     val numReadings: Int
         get() {
-            checkKeysGenerated()
             return readingKeys!!.size
         }
 
     val getReadingKeys: List<Key>
         get() {
-            checkKeysGenerated()
             return readingKeys!!
         }
 
@@ -102,7 +108,6 @@ class OneDaysReadingsDto(val day: Int,
     }
 
     fun getReadingKey(no: Int): Key {
-        checkKeysGenerated()
         return readingKeys!![no]
     }
 
@@ -134,16 +139,12 @@ class OneDaysReadingsDto(val day: Int,
         }
     }
 
-    @SuppressLint("SimpleDateFormat")
-    private val dateBasedFormatMonthDay = SimpleDateFormat("MMM-d")
-    @SuppressLint("SimpleDateFormat")
-    private val dateBasedFormatWithYear = SimpleDateFormat("MMM-d/yyyy")
-
     /**
      * @param dateString Must be in this format: Feb-1, Mar-22, Dec-11, etc
      */
     private fun dateFormatterPlanStringToDate(dateString: String): Date {
-        return dateBasedFormatWithYear.parse(dateString + "/" + Calendar.getInstance().get(Calendar.YEAR))
+        val calYear = Calendar.getInstance().get(Calendar.YEAR)
+        return dateBasedFormatWithYear.parse("$dateString/$calYear")
     }
 
     /**

--- a/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
+++ b/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
@@ -55,7 +55,7 @@ class OneDaysReadingsDto(val day: Int,
     val dayDesc: String get() = BibleApplication.application.getString(R.string.rdg_plan_day, Integer.toString(day))
     val isDateBasedPlan: Boolean
         get() {
-            return readingDate != null
+            return readingPlanInfo.isDateBasedPlan
         }
 
     /** get a string representing the date this reading is planned for

--- a/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
+++ b/app/src/main/java/net/bible/service/readingplan/OneDaysReadingsDto.kt
@@ -52,7 +52,7 @@ class OneDaysReadingsDto(val day: Int,
         checkKeysGenerated()
     }
 
-    val dayDesc: String get() = BibleApplication.application.getString(R.string.rdg_plan_day, Integer.toString(day))
+    val dayDesc: String get() = BibleApplication.application.getString(R.string.rdg_plan_day, day.toString())
     val isDateBasedPlan: Boolean
         get() {
             return readingPlanInfo.isDateBasedPlan
@@ -147,12 +147,5 @@ class OneDaysReadingsDto(val day: Int,
     private fun dateFormatterPlanStringToDate(dateString: String): Date {
         val calYear = Calendar.getInstance().get(Calendar.YEAR)
         return dateBasedFormatWithYear.parse("$dateString/$calYear")
-    }
-
-    /**
-     * @return Will return string in this format: Feb-1, Mar-22, Dec-11, etc
-     */
-    private fun dateFormatterPlanDateToString(date: Date): String {
-        return dateBasedFormatMonthDay.format(date).toString()
     }
 }

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
@@ -121,13 +121,11 @@ class ReadingPlanDao {
 
         val list = ArrayList<OneDaysReadingsDto>()
         for ((key1, value1) in properties) {
-            val key = key1 as String
-            val value = value1 as String
-            if (key.toIntOrNull() != null) {
-                val day = Integer.parseInt(key)
-                val daysReading = OneDaysReadingsDto(day, value, planInfo)
-                list.add(daysReading)
-            }
+            val dayNumber = (key1 as String).toIntOrNull() ?: continue
+            val readingString = value1 as String
+
+            val daysReading = OneDaysReadingsDto(dayNumber, readingString, planInfo)
+            list.add(daysReading)
         }
         list.sort()
 

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
@@ -46,6 +46,7 @@ import kotlin.math.max
  */
 class ReadingPlanDao {
     private var cachedPlanProperties: ReadingPlanProperties? = null
+    private var cachedReadingList: List<OneDaysReadingsDto>? = null
 
     val readingPlanList: List<ReadingPlanInfoDto>
         get() {
@@ -113,23 +114,26 @@ class ReadingPlanDao {
 
     /** get a list of all days readings in a plan
      */
-    fun getReadingList(planName: String): List<OneDaysReadingsDto> {
+    fun getReadingList(planCode: String): List<OneDaysReadingsDto> {
 
-        val planInfo = getReadingPlanInfoDto(planName)
+        var list: ArrayList<OneDaysReadingsDto>? = null
+        if (planCode != cachedPlanProperties?.planCode || cachedReadingList == null) {
+            list = ArrayList()
+            val planInfo = getReadingPlanInfoDto(planCode)
+            val properties = getPlanProperties(planCode)
 
-        val properties = getPlanProperties(planName)
+            for ((key1, value1) in properties) {
+                val dayNumber = (key1 as String).toIntOrNull() ?: continue
+                val readingString = value1 as String
 
-        val list = ArrayList<OneDaysReadingsDto>()
-        for ((key1, value1) in properties) {
-            val dayNumber = (key1 as String).toIntOrNull() ?: continue
-            val readingString = value1 as String
-
-            val daysReading = OneDaysReadingsDto(dayNumber, readingString, planInfo)
-            list.add(daysReading)
+                val daysReading = OneDaysReadingsDto(dayNumber, readingString, planInfo)
+                list.add(daysReading)
+            }
+            list.sort()
+            cachedReadingList = list
         }
-        list.sort()
 
-        return list
+        return list ?: cachedReadingList!!
     }
 
     /** get readings for one day

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
@@ -193,7 +193,7 @@ class ReadingPlanDao {
             Versifications.instance().getVersification(INCLUSIVE_VERSIFICATION)
         }
 
-    private fun getReadingPlanInfoDto(planCode: String): ReadingPlanInfoDto {
+    fun getReadingPlanInfoDto(planCode: String): ReadingPlanInfoDto {
         Log.d(TAG, "Get reading plan info:$planCode")
         val info = ReadingPlanInfoDto(planCode)
 

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
@@ -251,7 +251,7 @@ class ReadingPlanDao {
                     FileInputStream(userReadingPlanFile)
                 }
 
-                val byteArrayForReuse = ByteArrayOutputStream().apply {write(inputStreamRaw.readBytes())}
+                val byteArrayForReuse = ByteArrayOutputStream().apply { write(inputStreamRaw?.readBytes()) }
                 properties.load(ByteArrayInputStream(byteArrayForReuse.toByteArray()))
                 properties.planCode = planCode
                 properties.numberOfPlanDays = getNumberOfPlanDays(properties)
@@ -307,13 +307,13 @@ class ReadingPlanDao {
 
     companion object {
 
-        private val READING_PLAN_FOLDER = SharedConstants.READINGPLAN_DIR_NAME
         private val USER_READING_PLAN_FOLDER = SharedConstants.MANUAL_READINGPLAN_DIR
-        private val DOT_PROPERTIES = ".properties"
-        private val VERSIFICATION = "Versification"
-        private val DEFAULT_VERSIFICATION = SystemKJV.V11N_NAME
-        private val INCLUSIVE_VERSIFICATION = SystemNRSVA.V11N_NAME
+        private const val READING_PLAN_FOLDER = SharedConstants.READINGPLAN_DIR_NAME
+        private const val DOT_PROPERTIES = ".properties"
+        private const val VERSIFICATION = "Versification"
+        private const val DEFAULT_VERSIFICATION = SystemKJV.V11N_NAME
+        private const val INCLUSIVE_VERSIFICATION = SystemNRSVA.V11N_NAME
 
-        private val TAG = "ReadingPlanDao"
+        private const val TAG = "ReadingPlanDao"
     }
 }

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
@@ -115,9 +115,9 @@ class ReadingPlanDao {
     /** get a list of all days readings in a plan
      */
     fun getReadingList(planCode: String): List<OneDaysReadingsDto> {
-
         var list: ArrayList<OneDaysReadingsDto>? = null
-        if (planCode != cachedPlanProperties?.planCode || cachedReadingList == null) {
+        if (cachedReadingList == null || planCode != cachedReadingList!![0].readingPlanInfo.planCode) {
+            Log.i(TAG,"Getting List of days readings for plan $planCode")
             list = ArrayList()
             val planInfo = getReadingPlanInfoDto(planCode)
             val properties = getPlanProperties(planCode)

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
@@ -201,6 +201,7 @@ class ReadingPlanDao {
         info.planDescription = getPlanDescription(planCode)
         info.numberOfPlanDays = getNumberOfPlanDays(planCode)
         info.versification = getReadingPlanVersification(planCode)
+        info.isDateBasedPlan = getPlanProperties(planCode).isDateBasedPlan
 
         return info
     }
@@ -255,6 +256,7 @@ class ReadingPlanDao {
                 properties.planCode = planCode
                 properties.numberOfPlanDays = getNumberOfPlanDays(properties)
                 properties.versification = getReadingPlanVersification(properties)
+                properties.isDateBasedPlan = properties[1].toString().contains("^([a-z]|[A-Z]){3}-([0-9]{1,2});".toRegex())
                 getNameAndDescFromProperties(ByteArrayInputStream(byteArrayForReuse.toByteArray()), properties)
 
                 Log.d(TAG, "The properties are now loaded")
@@ -300,6 +302,7 @@ class ReadingPlanDao {
         var planDescription: String? = null
         var versification: Versification? = null
         var numberOfPlanDays = 0
+        var isDateBasedPlan = false
     }
 
     companion object {

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanDao.kt
@@ -256,7 +256,7 @@ class ReadingPlanDao {
                 properties.planCode = planCode
                 properties.numberOfPlanDays = getNumberOfPlanDays(properties)
                 properties.versification = getReadingPlanVersification(properties)
-                properties.isDateBasedPlan = properties[1].toString().contains("^([a-z]|[A-Z]){3}-([0-9]{1,2});".toRegex())
+                properties.isDateBasedPlan = properties["1"].toString().contains("^([a-z]|[A-Z]){3}-([0-9]{1,2});".toRegex())
                 getNameAndDescFromProperties(ByteArrayInputStream(byteArrayForReuse.toByteArray()), properties)
 
                 Log.d(TAG, "The properties are now loaded")

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanInfoDto.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanInfoDto.kt
@@ -29,7 +29,7 @@ import java.util.Date
 /**
  * @author Martin Denham [mjdenham at gmail dot com]
  */
-class ReadingPlanInfoDto(var code: String) {
+class ReadingPlanInfoDto(var planCode: String) {
     var planName: String? = null
     var planDescription: String? = null
     var versification: Versification? = null
@@ -40,7 +40,7 @@ class ReadingPlanInfoDto(var code: String) {
      */
     val startdate: Date?
         get() {
-            val startDate = CommonUtils.sharedPreferences.getLong(code + READING_PLAN_START_EXT, 0)
+            val startDate = CommonUtils.sharedPreferences.getLong(planCode + READING_PLAN_START_EXT, 0)
             return if (startDate == 0L) {
                 null
             } else {
@@ -65,7 +65,7 @@ class ReadingPlanInfoDto(var code: String) {
 
             CommonUtils.sharedPreferences
                     .edit()
-                    .putLong(code + READING_PLAN_START_EXT, date.time)
+                    .putLong(planCode + READING_PLAN_START_EXT, date.time)
                     .apply()
         }
     }
@@ -78,7 +78,7 @@ class ReadingPlanInfoDto(var code: String) {
         if (startdate == null) {
             CommonUtils.sharedPreferences
                     .edit()
-                    .remove(code + READING_PLAN_START_EXT)
+                    .remove(planCode + READING_PLAN_START_EXT)
                     .apply()
         }
     }

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanInfoDto.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanInfoDto.kt
@@ -19,11 +19,10 @@
 package net.bible.service.readingplan
 
 import net.bible.service.common.CommonUtils
+import net.bible.service.db.readingplan.ReadingPlanDbAdapter
 
-import org.apache.commons.lang3.time.DateUtils
 import org.crosswire.jsword.versification.Versification
 
-import java.util.Calendar
 import java.util.Date
 
 /**
@@ -34,18 +33,16 @@ class ReadingPlanInfoDto(var planCode: String) {
     var planDescription: String? = null
     var versification: Versification? = null
     var numberOfPlanDays: Int = 0
+    val rAdapter = ReadingPlanDbAdapter.instance
 
     /** a persistent start date
      * return the date the plan was started or null if not started
      */
     val startdate: Date?
         get() {
-            val startDate = CommonUtils.sharedPreferences.getLong(planCode + READING_PLAN_START_EXT, 0)
-            return if (startDate == 0L) {
-                null
-            } else {
-                Date(startDate)
-            }
+            val startDate = rAdapter.getReadingStartDate(planCode)
+            startDate ?: return null
+            return Date(startDate)
         }
 
     /** set a persistent start date
@@ -61,34 +58,12 @@ class ReadingPlanInfoDto(var planCode: String) {
     private fun startOn(date: Date, force: Boolean) {
 
         // if changing plan
-        if (startdate == null || force) {
-
-            CommonUtils.sharedPreferences
-                    .edit()
-                    .putLong(planCode + READING_PLAN_START_EXT, date.time)
-                    .apply()
-        }
-    }
-
-    /** set a persistent start date
-     */
-    fun reset() {
-
-        // if changing plan
-        if (startdate == null) {
-            CommonUtils.sharedPreferences
-                    .edit()
-                    .remove(planCode + READING_PLAN_START_EXT)
-                    .apply()
-        }
+        if (startdate == null || force)
+            rAdapter.setReadingStartDate(planCode, date.time)
     }
 
     override fun toString(): String {
         return "$planName"
     }
 
-    companion object {
-
-        val READING_PLAN_START_EXT = "_start"
-    }
 }

--- a/app/src/main/java/net/bible/service/readingplan/ReadingPlanInfoDto.kt
+++ b/app/src/main/java/net/bible/service/readingplan/ReadingPlanInfoDto.kt
@@ -33,6 +33,7 @@ class ReadingPlanInfoDto(var planCode: String) {
     var planDescription: String? = null
     var versification: Versification? = null
     var numberOfPlanDays: Int = 0
+    var isDateBasedPlan: Boolean = false
     val rAdapter = ReadingPlanDbAdapter.instance
 
     /** a persistent start date

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,7 @@ TODO: error and download_document_confirm_prefix need to be parameterized rather
     <string name="rdg_plan_set_start_date">Set Start Date...</string>
     <string name="done">Done</string>
     <string name="reset">Reset</string>
+    <string name="reset_plan_question">Are you sure you want to reset this plan?</string>
     <string name="plan_duplicate_user_plan">
         There is a user reading plan in sdcard
         jsword/readingplan with the same name as an internal plan. It can not be listed here.


### PR DESCRIPTION
NOTICE ! This PR changes database version from v5 to v6. Once updated, it is currently not possible to downgrade reading plan status back to v5. App could be uninstalled and reinstalled to v5 and everything else restored from v5 backup, but reading status would be lost. v6 backup can not be restored to v5 of app.
Closes #55 
Closes #292 You can test date-based reading plan with [this file](https://github.com/AndBible/and-bible/files/3851994/roberts.txt). You must change the file extension to .properties

**Another improvement:** user is asked to confirm when selecting plan reset button.

