### PR TITLE
Metadata for F-Droid

### DIFF
--- a/fastlane/metadata/android/eo/full_description.txt
+++ b/fastlane/metadata/android/eo/full_description.txt
@@ -1,4 +1,4 @@
-And Biblio estas malfermkoda, senkonekta kaj tute senpaga aplikaĵo por legi Biblion sen reklamoj por plifaciligi legi, aŭskulti kaj studi Sanktan Skripton al homoj de ĉiuj landoj kun la plej granda persona beno.
+And Biblio (And Bible) estas malfermkoda, senkonekta kaj tute senpaga aplikaĵo por legi Biblion sen reklamoj por plifaciligi legi, aŭskulti kaj studi Sanktan Skripton al homoj de ĉiuj landoj kun la plej granda persona beno.
 
 * Biblioj, komentoj, teologiaj vortaroj, mapoj kaj kristanaj libroj en pli ol 700 lingvoj
 * tute senkonekta post unua elŝuto, serĉebla, inkluzivante notojn, komentojn, ktp.

--- a/fastlane/metadata/android/eo/full_description.txt
+++ b/fastlane/metadata/android/eo/full_description.txt
@@ -1,0 +1,28 @@
+And Biblio estas malfermkoda, senkonekta kaj tute senpaga aplikaĵo por legi Biblion sen reklamoj por plifaciligi legi, aŭskulti kaj studi Sanktan Skripton al homoj de ĉiuj landoj kun la plej granda persona beno.
+
+* Biblioj, komentoj, teologiaj vortaroj, mapoj kaj kristanaj libroj en pli ol 700 lingvoj
+* tute senkonekta post unua elŝuto, serĉebla, inkluzivante notojn, komentojn, ktp.
+* fasado de programo en Esperanto, ĉina, rusa, germana, franca, hungara, pola, ĉeĥa, hebrea, hindia…
+* diversaj planoj de legado
+* tute senpaga, neniuj reklamoj
+* Esperanta Londona Biblio
+* komentoj (nedisponeblaj en EO)
+* teologia vortaro kaj kolekto de kristanaj libroj (nedisponeblaj en EO)
+* ĉiuj dokumentoj laŭleĝe distribuataj
+* numeroj de Strong por analizi vortojn en greka kaj hebrea
+* ekran‑dividebla
+* eblo skribi personajn notojn
+* ŝanĝebla lingvo de fasado (25 lingvoj)
+* fleksebla serĉo
+* legosignoj
+* mapoj de Bibliaj regionoj
+* aŭskulti iun ajn dokumenton
+* aŭtomataj rulumado kaj taga/nokta reĝimo
+* kompari tradukojn de Biblio sur unu ekrano
+* unu el la plej rapidaj legiloj de Biblio por Androido
+* malfermkoda – plibonigu aŭ ŝanĝu la fontkodon se vi volas
+* uzas la potencan modulon JSword de CrossWire
+
+Ni ĉiuj estas volontuloj; nie ne sendas turmentajn retleterojn, ne montras tedajn reklamojn; neniam petas pri donacoj; ne patas pri registri; la programo And Biblio kolektas neniujn datumojn el via telefono.
+
+La deveno de ĉiuj dokumentoj estas kontrolita por certigi, ke ĉiuj dokumentoj povas esti laŭleĝe distribuataj aŭ ricevis permeson de kopirajt‑posedantoj.

--- a/fastlane/metadata/android/eo/full_description.txt
+++ b/fastlane/metadata/android/eo/full_description.txt
@@ -26,3 +26,7 @@ And Biblio (And Bible) estas malfermkoda, senkonekta kaj tute senpaga aplikaĵo 
 Ni ĉiuj estas volontuloj; nie ne sendas turmentajn retleterojn, ne montras tedajn reklamojn; neniam petas pri donacoj; ne patas pri registri; la programo And Biblio kolektas neniujn datumojn el via telefono.
 
 La deveno de ĉiuj dokumentoj estas kontrolita por certigi, ke ĉiuj dokumentoj povas esti laŭleĝe distribuataj aŭ ricevis permeson de kopirajt‑posedantoj.
+
+<b>Rimarkoj:</b>
+* ŝatu na And Biblio ĉe <a href="https://facebook.com/AndBible/">Facebook</a>
+* plej oftaj demandoj (en la angla) pri And Biblio: <a href="https://github.com/AndBible/and-bible/wiki/FAQ">FAQ</a>

--- a/fastlane/metadata/android/eo/name.txt
+++ b/fastlane/metadata/android/eo/name.txt
@@ -1,0 +1,1 @@
+And Biblio

--- a/fastlane/metadata/android/eo/short_description.txt
+++ b/fastlane/metadata/android/eo/short_description.txt
@@ -1,0 +1,1 @@
+Studi Biblion en pli ol 700 lingvoj; legi komentoj k vortaroj; senkonekte.

--- a/fastlane/metadata/android/pl/full_description.txt
+++ b/fastlane/metadata/android/pl/full_description.txt
@@ -1,0 +1,32 @@
+And Bible jest otwartoźródłową, działającą offline, całkowicie bezpłatną aplikacją do czytania Biblii bez jakichkolwiek reklam, aby ułatwić czytanie i odsłuch Pisma Świętego ludziom ze wszystkich krajów z jak największym osobistym błogosławieństwem.
+
+* Biblie, komentarze, słowniki teologiczne, mapy i książki chrześcijańskie w przeszło 700 językach
+* nie wymaga połączenia z internetem po pierwszym pobraniu danych, włączając wyszukiwanie, notatki, komentarze, itd.
+* interfejs programu w języku polskim, chińskim, rosyjskim, Esperanto, niemieckim, francuskim, węgierskim, czeskim, hebrajskim, hindi…
+* wiele różnych planów czytania
+* całkowicie bezpłatna i bez reklam
+* Uwspółcześniona Biblia gdańska
+* komentarze (niedostępne w j. polskim)
+* słowniki teologiczne i kolekcja książek chrześcijańskich (niedostępne w j. polskim)
+* wszystkie dokumenty są rozprowadzane zgodnie z licencją (dlatego nie jest dostępna np. Biblia Tysiąclecia)
+* numeracja Stronga, aby móc analizować słowa w grece i hebrajskim
+* tryb podzielnego ekranu
+* możliwość umieszczanie notatek osobistych
+* możliwość zmiany języka interfejsu programu (ponad 25 języków)
+* elastyczne wyszukiwanie
+* zakładki
+* mapy krain biblijnych
+* możliwość odsłuchu dowolnego dokumentu
+* automatyczne przewijanie, automatyczny tryb dzienny/nocny
+* porównywanie tłumaczeń Biblii na jednym ekranie
+* jeden z najszybszych czytników Biblii na Androida
+* otwarty kod «open source» – zajrzyj lub wprowadź własne poprawki do kodu źródłowego
+* korzysta z silnika JSword od CrossWire
+
+Jesteśmy wolontariuszami; nie wysyłamy irytujących el-listów, nie wyświetlamy męczących reklam, nie prosimy o datki, nie prosimy o rejestrację; aplikacja And Bible nie zbiera jakichkolwiek danych z Twojego telefonu.
+
+Pochodzenie wszystkich dokumentów zostało sprawdzone, aby upewnić się, że mogą one być rozpowszechniane nie naruszając praw autorskich. Z tego powodu aplikacja nie zawiera  np. Biblii Tysiąclecia.
+
+<b>Uwagi</b>:
+* polub nas na <a href="https://facebook.com/AndBible/">Facebooku</a>
+* częste pytania (w j. angielskim) dotyczące aplikacji And Bible: <a href="https://github.com/AndBible/and-bible/wiki/FAQ">FAQ</a>

--- a/fastlane/metadata/android/pl/short_description.txt
+++ b/fastlane/metadata/android/pl/short_description.txt
@@ -1,0 +1,1 @@
+Czytaj Biblię w przeszło 700 językach; komentarze i słowniki, bez internetu.


### PR DESCRIPTION
EO
Mi aldonis metadatumojn (fastlane) por F-Droid en Esperanto kaj pola lingvoj. Mi transsaltis la lastan frazon (“* projekt‑paĝo ĉe GitHub…”), ćar la ligilo al GitHub jam estas disponebla per F-Droid.

EN
I added metadata (fastlane) for F-Droid in Esperanto and Polish. I skipped the last sentence ("* project page on GitHub ..."), because the link to GitHub is already available with F-Droid.