### PR TITLE
Make NoteRef and MyNoteMarker clickable

### DIFF
--- a/app/src/main/java/net/bible/android/control/link/LinkControl.kt
+++ b/app/src/main/java/net/bible/android/control/link/LinkControl.kt
@@ -262,6 +262,8 @@ class LinkControl @Inject constructor(
         }
     }
 
+    // TODO: Currently there's a bit of code duplication between these functions and 
+    // VerseMenuCommandHandler.java:handleMenuRequest
     private fun showNote(osisRef: String?, note: String) {
         val activity = CurrentActivityHolder.getInstance().currentActivity
         val handlerIntent = Intent(activity, FootnoteAndRefActivity::class.java)

--- a/app/src/main/java/net/bible/android/control/link/UriAnalyzer.kt
+++ b/app/src/main/java/net/bible/android/control/link/UriAnalyzer.kt
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.StringUtils
  */
 class UriAnalyzer {
     enum class DocType {
-        BIBLE, GREEK_DIC, HEBREW_DIC, ROBINSON, ALL_GREEK, ALL_HEBREW, SPECIFIC_DOC
+        BIBLE, GREEK_DIC, HEBREW_DIC, ROBINSON, ALL_GREEK, ALL_HEBREW, SPECIFIC_DOC, NOTE, MYNOTE
     }
 
     var docType = DocType.BIBLE
@@ -71,6 +71,10 @@ class UriAnalyzer {
             DocType.ALL_GREEK
         } else if (Constants.ALL_HEBREW_OCCURRENCES_PROTOCOL == protocol) {
             DocType.ALL_HEBREW
+        } else if (Constants.NOTE_PROTOCOL == protocol) {
+            DocType.NOTE
+        } else if (Constants.MYNOTE_PROTOCOL == protocol) {
+            DocType.MYNOTE
         } else { // not a valid Strongs Uri
             return false
         }

--- a/app/src/main/java/net/bible/service/common/Constants.kt
+++ b/app/src/main/java/net/bible/service/common/Constants.kt
@@ -30,6 +30,8 @@ object Constants {
     const val DICTIONARY_PROTOCOL = "dict" //$NON-NLS-1$
     const val GREEK_DEF_PROTOCOL = "gdef" //$NON-NLS-1$
     const val HEBREW_DEF_PROTOCOL = "hdef" //$NON-NLS-1$
+    const val NOTE_PROTOCOL = "note"
+    const val MYNOTE_PROTOCOL = "mynote"
     const val ALL_GREEK_OCCURRENCES_PROTOCOL = "allgoccur" //$NON-NLS-1$
     const val ALL_HEBREW_OCCURRENCES_PROTOCOL = "allhoccur" //$NON-NLS-1$
     const val ROBINSON_GREEK_MORPH_PROTOCOL = "robinson" //$NON-NLS-1$

--- a/app/src/main/java/net/bible/service/format/osistohtml/taghandler/MyNoteMarker.kt
+++ b/app/src/main/java/net/bible/service/format/osistohtml/taghandler/MyNoteMarker.kt
@@ -17,6 +17,7 @@
  */
 package net.bible.service.format.osistohtml.taghandler
 
+import net.bible.service.common.Constants
 import net.bible.service.common.Logger
 import net.bible.service.format.osistohtml.HtmlTextWriter
 import net.bible.service.format.osistohtml.OsisToHtmlParameters
@@ -40,7 +41,12 @@ class MyNoteMarker(private val parameters: OsisToHtmlParameters,
     override fun start(attr: Attributes) {
         if (parameters.isShowMyNotes) {
             if (myNoteVerses.contains(verseInfo.currentVerseNo)) {
-                writer.write("<img src='file:///android_asset/images/pencil16x16.png' class='myNoteImg'/>")
+                var tag: String = "<a href='%s:%s'><img src='%s' class='myNoteImg'/></a>".format(
+                    Constants.MYNOTE_PROTOCOL,
+                    parameters.basisRef.osisID + verseInfo.currentVerseNo,
+                    "file:///android_asset/images/pencil16x16.png"
+                )
+                writer.write(tag)
             }
         }
     }

--- a/app/src/main/java/net/bible/service/format/osistohtml/taghandler/NoteHandler.kt
+++ b/app/src/main/java/net/bible/service/format/osistohtml/taghandler/NoteHandler.kt
@@ -17,6 +17,7 @@
  */
 package net.bible.service.format.osistohtml.taghandler
 
+import net.bible.service.common.Constants
 import net.bible.service.common.Logger
 import net.bible.service.format.Note
 import net.bible.service.format.Note.NoteType
@@ -154,7 +155,12 @@ class NoteHandler(
      */
     private fun writeNoteRef(noteRef: String?) {
         if (parameters.isShowNotes) {
-            writer.write("<span class='noteRef'>$noteRef</span> ")
+            var tag: String = "<a href='%s:%s/%s' class='noteRef'>%s</a>".format(
+                Constants.NOTE_PROTOCOL,
+                parameters.basisRef.osisID + verseInfo.currentVerseNo,
+                noteRef,
+                noteRef)
+            writer.write(tag)
         }
     }
 


### PR DESCRIPTION
Click on the MyNotes image or NoteRef to go to the corresponding activity

It works by wrapping the reference text in `<a> </a>` with a special url format, which is parsed by the UriAnalyzer to open the right activity
