### PR TITLE
Bugfix clickable notes first chapter

### DIFF
--- a/app/src/main/java/net/bible/service/format/osistohtml/osishandlers/OsisToHtmlSaxHandler.kt
+++ b/app/src/main/java/net/bible/service/format/osistohtml/osishandlers/OsisToHtmlSaxHandler.kt
@@ -91,6 +91,8 @@ class OsisToHtmlSaxHandler(// properties
 
     class VerseInfo {
         @JvmField
+        var osisID:String? = null
+        @JvmField
         var currentVerseNo = 0
         @JvmField
         var positionToInsertBeforeVerse = 0

--- a/app/src/main/java/net/bible/service/format/osistohtml/taghandler/NoteHandler.kt
+++ b/app/src/main/java/net/bible/service/format/osistohtml/taghandler/NoteHandler.kt
@@ -154,10 +154,14 @@ class NoteHandler(
     /** write noteref html to outputstream
      */
     private fun writeNoteRef(noteRef: String?) {
+        var osisID = verseInfo.osisID
+        if (osisID == null) {
+            osisID = "${parameters.basisRef}${verseInfo.currentVerseNo}"
+        }
         if (parameters.isShowNotes) {
             var tag: String = "<a href='%s:%s/%s' class='noteRef'>%s</a> ".format(
                 Constants.NOTE_PROTOCOL,
-                parameters.basisRef.osisID + verseInfo.currentVerseNo,
+                osisID,
                 noteRef,
                 noteRef)
             writer.write(tag)

--- a/app/src/main/java/net/bible/service/format/osistohtml/taghandler/VerseHandler.java
+++ b/app/src/main/java/net/bible/service/format/osistohtml/taghandler/VerseHandler.java
@@ -76,6 +76,8 @@ public class VerseHandler implements OsisTagHandler {
 		Integer verseNo = calculateVerseNumber(attrs, verseInfo.currentVerseNo);
 		verseInfo.currentVerseNo = verseNo;
 
+		verseInfo.osisID = attrs.getValue(OSISUtil.OSIS_ATTR_OSISID);
+
 		if (parameters.isVersePerline()) {
 			//close preceding verse
 			if (verseInfo.currentVerseNo>1) {


### PR DESCRIPTION
Get the current verse from the verseInfo, instead of basisRef. This is more reliable.

Also update the tests to match and added a regression test.