### PR TITLE
Make the search activity keep state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,7 +49,6 @@
             android:name="net.bible.android.view.activity.page.MainBibleActivity"
             android:configChanges="keyboardHidden|screenSize|locale|uiMode"
             android:windowSoftInputMode="stateHidden|adjustPan"
-            android:launchMode="singleTask"
             android:label="@string/app_name_short" />
         <activity
             android:name="net.bible.android.view.activity.navigation.ChooseDocument"

--- a/app/src/main/java/net/bible/android/view/activity/search/Search.kt
+++ b/app/src/main/java/net/bible/android/view/activity/search/Search.kt
@@ -210,16 +210,6 @@ class Search : CustomTitlebarActivityBase(R.menu.search_actionbar_menu) {
         return searchControl.decorateSearchString(searchString, searchType, bibleSection, currentBookName)
     }
 
-    /** I don't think this is used because of hte finish() in onSearch()
-     * TODO remove
-     */
-    @SuppressLint("MissingSuperCall")
-    public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (resultCode == Activity.RESULT_OK) {
-            returnToPreviousScreen()
-        }
-    }
-
     companion object {
 
         private const val SEARCH_TEXT_SAVE = "Search"

--- a/app/src/main/java/net/bible/android/view/activity/search/SearchResults.kt
+++ b/app/src/main/java/net/bible/android/view/activity/search/SearchResults.kt
@@ -18,6 +18,7 @@
 package net.bible.android.view.activity.search
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -35,6 +36,7 @@ import net.bible.android.control.search.SearchControl
 import net.bible.android.control.search.SearchResultsDto
 import net.bible.android.view.activity.base.Dialogs
 import net.bible.android.view.activity.base.ListActivityBase
+import net.bible.android.view.activity.page.MainBibleActivity
 import net.bible.android.view.activity.search.searchresultsactionbar.SearchResultsActionBarManager
 import org.apache.commons.lang3.StringUtils
 import org.crosswire.jsword.passage.Key
@@ -152,7 +154,10 @@ class SearchResults : ListActivityBase(R.menu.empty_menu) {
             val targetBook = swordDocumentFacade.getDocumentByInitials(targetDocInitials)
             activeWindowPageManagerProvider.activeWindowPageManager.setCurrentDocumentAndKey(targetBook, key)
             // this also calls finish() on this Activity.  If a user re-selects from HistoryList then a new Activity is created
-            returnToPreviousScreen()
+            val intent = Intent(this, MainBibleActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            }
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/java/net/bible/service/history/IntentHistoryItem.kt
+++ b/app/src/main/java/net/bible/service/history/IntentHistoryItem.kt
@@ -58,6 +58,7 @@ class IntentHistoryItem(
         // need to get current activity and call startActivity on that
         val currentActivity = CurrentActivityHolder.getInstance().currentActivity
 
+        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
         // start activity chosen from activity
         currentActivity.startActivityForResult(intent, STD_REQUEST_CODE)
     }


### PR DESCRIPTION
Instead of calling finish() to return to the previous screen,
we start a new intent for the MainBibleActivity with FLAG_ACTIVITY_REORDER_TO_FRONT
to move the MainBibleActivity to the front and the SearchResults to the back.

Then upon pressing the back button, the SearchResults activity is moved to the front again.

**Describe the pull request content**
Fix #629 
It has a possible side effect of undoing the fix for #294, so please test that. I could not reproduce it though.
