### PR TITLE
Fixes regression from 6be260f, basisRef not initialized for some book…

### DIFF
--- a/app/src/main/java/net/bible/service/format/osistohtml/OsisToHtmlParameters.kt
+++ b/app/src/main/java/net/bible/service/format/osistohtml/OsisToHtmlParameters.kt
@@ -46,7 +46,7 @@ class OsisToHtmlParameters {
 
     // KeyUtil always returns a Verse even if it is only Gen 1:1
     // used as a basis if a reference has only chapter and no book
-    lateinit var basisRef: Verse
+    var basisRef: Verse? = null
 
     fun setBasicRef(value: Key) {
         // KeyUtil always returns a Verse even if it is only Gen 1:1

--- a/app/src/main/java/net/bible/service/format/osistohtml/taghandler/MyNoteMarker.kt
+++ b/app/src/main/java/net/bible/service/format/osistohtml/taghandler/MyNoteMarker.kt
@@ -40,10 +40,11 @@ class MyNoteMarker(private val parameters: OsisToHtmlParameters,
      */
     override fun start(attrs: Attributes) {
         if (parameters.isShowMyNotes) {
-            if (myNoteVerses.contains(verseInfo.currentVerseNo)) {
+            val basisRef = parameters.basisRef
+            if (myNoteVerses.contains(verseInfo.currentVerseNo) && basisRef != null) {
                 val tag: String = "<a href='%s:%s'><img src='%s' class='myNoteImg'/></a>".format(
                     Constants.MYNOTE_PROTOCOL,
-                    parameters.basisRef.osisID + verseInfo.currentVerseNo,
+                    basisRef.osisID + verseInfo.currentVerseNo,
                     "file:///android_asset/images/pencil16x16.png"
                 )
                 writer.write(tag)

--- a/app/src/main/java/net/bible/service/format/osistohtml/taghandler/NoteHandler.kt
+++ b/app/src/main/java/net/bible/service/format/osistohtml/taghandler/NoteHandler.kt
@@ -165,7 +165,7 @@ class NoteHandler(
         if (osisID == null) {
             osisID = "${parameters.basisRef}${verseInfo.currentVerseNo}"
         }
-        if (parameters.isShowNotes) {
+        if (parameters.isShowNotes && parameters.basisRef != null) {
             val tag: String = "<a href='%s:%s/%s' class='noteRef'>%s</a> ".format(
                 Constants.NOTE_PROTOCOL,
                 osisID,

--- a/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.kt
+++ b/app/src/main/java/net/bible/service/format/osistohtml/taghandler/ReferenceHandler.kt
@@ -100,9 +100,9 @@ open class ReferenceHandler(
             val firstColonPos = content.indexOf(":")
             val isVerseAndChapter = firstColonPos in 1..3
             reference = if (isVerseAndChapter) {
-                parameters.basisRef.book.osis + " " + content
+                parameters.basisRef!!.book.osis + " " + content
             } else {
-                parameters.basisRef.book.osis + " " + parameters.basisRef.chapter + ":" + content
+                parameters.basisRef!!.book.osis + " " + parameters.basisRef!!.chapter + ":" + content
             }
             log.debug("Patched reference:$reference")
         } else if (content != null) {


### PR DESCRIPTION
Fixes #672 

NoteHandler tries to get basisRef for everything, even genbooks. But since AB does not have functionality of notes for genbooks yet, disabled note tag writer when basisRef is null