### PR TITLE
Prevent crash on note with invalid versification

### DIFF
--- a/app/src/main/java/net/bible/android/control/versification/sort/VersificationPrioritiser.java
+++ b/app/src/main/java/net/bible/android/control/versification/sort/VersificationPrioritiser.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import kotlin.KotlinNullPointerException;
+
 /**
  * Using the list of preferred v11ns calculated from the total list of verses passed in
  *
@@ -44,7 +46,11 @@ class VersificationPrioritiser {
 	private List<Versification> getVersifications(List<? extends ConvertibleVerseRangeUser> convertibleVerseRangeUsers) {
 		List<Versification> versifications = new ArrayList<>();
 		for (ConvertibleVerseRangeUser cvru : convertibleVerseRangeUsers) {
-			versifications.add(cvru.getConvertibleVerseRange().getOriginalVersification());
+			try {
+				versifications.add(cvru.getConvertibleVerseRange().getOriginalVersification());
+			} catch (KotlinNullPointerException e) {
+				versifications.add(new Versification());
+			}
 		}
 
 		return versifications;


### PR DESCRIPTION
Ref #697

I catch the NullPointerException that is thrown and return a new versification instead.
This prevents a crash and we now hit this error: 

https://github.com/AndBible/and-bible/blob/2b0aab65b4e357827e311086b3811378abc06dca/app/src/main/java/net/bible/service/db/mynote/MyNoteDBAdapter.kt#L197

I think this is what we want, this error should not happen normally.

There are two alternatives to this implementation:
1. Set the versification to a fixed verse, i.e. Gen 1:1
2. Give the user the option to delete the note when that error happens.
