### PR TITLE
Added task commandLine conditions for windows

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,12 @@ task npmUpgrade(type: Exec) {
     outputs.file "bibleview-js/node_modules/.bin/npm"
     workingDir "bibleview-js"
     // Workaround for F-droid, which has buggy npm version 5.8, that always fails when installing packages.
-    commandLine "npx", "npm@latest", "install", "--save-dev", "npm@latest"
+    if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+        commandLine "npx.cmd", "npm@latest", "install", "--save-dev", "npm@latest"
+    }
+    else {
+        commandLine "npx", "npm@latest", "install", "--save-dev", "npm@latest"
+    }
 }
 
 task npmInstall(type: Exec, dependsOn: npmUpgrade) {
@@ -26,7 +31,12 @@ task npmInstall(type: Exec, dependsOn: npmUpgrade) {
     outputs.dir "bibleview-js/node_modules"
 
     workingDir "bibleview-js"
-    commandLine "node_modules/.bin/npm", "install"
+    if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+        commandLine "$rootDir/app/bibleview-js/node_modules/.bin/npm.cmd", "install"
+    }
+    else {
+        commandLine "node_modules/.bin/npm", "install"
+    }
 }
 
 task webpack(type: Exec, dependsOn: npmInstall) {
@@ -36,7 +46,12 @@ task webpack(type: Exec, dependsOn: npmInstall) {
     outputs.file "bibleview-js/dist/loader.js"
 
     workingDir "bibleview-js"
-    commandLine "node_modules/.bin/webpack"
+    if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+        commandLine "$rootDir/app/bibleview-js/node_modules/.bin/webpack.cmd"
+    }
+    else {
+        commandLine "node_modules/.bin/webpack"
+    }
 }
 
 task buildLoaderJs(type: Copy, dependsOn: webpack) {


### PR DESCRIPTION
**Describe the pull request content**
A clear and concise description of what the pull request is about.
Added the conditions for path values of commandLine for Windows users in build.gradle to fix #560 .

What are the benefits of this new code addition? 
It makes building the project in Windows possible.

Possible negative side effects? 
I haven't tried it out on a Linux platform, so there could be a problem there.



