### PR TITLE
Improvement - Add GitHub actions CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,19 +24,24 @@ jobs:
         # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0
         node-version: 10.x
 
-    - name: Cache gradle dependencies, test modules etc
-      id: cache
+    - name: Cache gradle dependencies
       uses: actions/cache@v2
       with:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
           ~/.android/build-cache
-          ~/.sword
-        key: ${{ runner.os }}-cache-20200615 # cache auto-removes if not accessed in 7 days. If data needs to refresh, change key name here (till https://github.com/actions/cache/issues/2 is addressed)
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+
+    - name: Cache test modules
+      id: cache-test-modules
+      uses: actions/cache@v2
+      with:
+        path: ~/.sword
+        key: ${{ runner.os }}-test-modules # cache auto-removes if not accessed in 7 days. If data needs to refresh, change key name here (till https://github.com/actions/cache/issues/2 is addressed)
 
     - name: Download test modules if not cached
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache-test-modules.outputs.cache-hit != 'true'
       run: |
         wget ${{ secrets.DOWNLOAD_TEST_MODULES_PATH }} -O ./testmods.zip.enc
         openssl enc -in ./testmods.zip.enc -out ./testmods.zip -d -aes-256-cbc -pbkdf2 -pass 'pass:${{ secrets.TEST_MODULE_KEY }}'
@@ -46,7 +51,7 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew --console plain build
 
-    - name: Before cache
+    - name: Before saving cache
       run: |
         rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
         rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,14 +27,23 @@ jobs:
     - run: mkdir testModules
 
     - name: Get modules from cache if exists
-      id: cache
+      id: cache-modules
       uses: actions/cache@v2
       with:
         path: testModules
         key: ${{ runner.os }}-modules
 
-    - name: Download modules if not cached
-      if: steps.cache.outputs.cache-hit != 'true'
+    - name: Cache gradle dependencies etc
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+          ~/.android/build-cache
+        key: ${{ runner.os }}-gradle-caches
+
+    - name: Download test modules if not cached
+      if: steps.cache-modules.outputs.cache-hit != 'true'
       run: wget ${{ secrets.DOWNLOAD_TEST_MODULES_PATH }} -O ./testModules/testmods.zip.enc
 
     - run: openssl enc -in ./testModules/testmods.zip.enc -out ./testmods.zip -d -aes-256-cbc -pbkdf2 -pass 'pass:${{ secrets.TEST_MODULE_KEY }}'
@@ -43,3 +52,8 @@ jobs:
 
     - name: Build with Gradle
       run: ./gradlew --console plain build
+
+    - name: Before cache
+      run: |
+        rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+        rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,7 @@ name: Android CI
 on:
   push:
     branches: [ master ]
-    tags: [ build-* ]
+    tags: [ build-*, beta-*, production-* ]
   pull_request:
     branches: [ master ]
 
@@ -56,7 +56,9 @@ jobs:
 
     - name: Get tag name
       id: tag_name
-      run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+      run: |
+        echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+        echo ::set-output name=TAG_TYPE::$(if [[ $GITHUB_REF =~ production- ]]; then echo "Release"; else echo "Beta"; fi)
 
     - name: Create apk release file
       if: contains(github.ref, 'refs/tags/')
@@ -70,7 +72,7 @@ jobs:
       run: |
         $ANDROID_HOME/build-tools/29.0.3/zipalign -v -p 4 app-release-unsigned.apk app-release-unsigned-aligned.apk
         echo ${{ secrets.JKS_BASE64 }} | base64 --decode > keystore.jks
-        $ANDROID_HOME/build-tools/29.0.3/apksigner sign --ks keystore.jks --ks-pass 'pass:${{ secrets.KEYSTORE_PASS }}' --key-pass 'pass:${{ secrets.KEY_PASS }}' --out $GITHUB_WORKSPACE/andbible-beta-$TAG_NAME.apk app-release-unsigned-aligned.apk
+        $ANDROID_HOME/build-tools/29.0.3/apksigner sign --ks keystore.jks --ks-pass 'pass:${{ secrets.KEYSTORE_PASS }}' --key-pass 'pass:${{ secrets.KEY_PASS }}' --out $GITHUB_WORKSPACE/andbible-$TAG_NAME.apk app-release-unsigned-aligned.apk
         rm -f keystore.jks
 
     - name: Create release
@@ -80,9 +82,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG_NAME: ${{ steps.tag_name.outputs.TAG }}
+        TAG_TYPE: ${{ steps.tag_name.outputs.TAG_TYPE }}
       with:
         tag_name: ${{ env.TAG_NAME }}
-        release_name: Beta ${{ env.TAG_NAME }}
+        release_name: ${{ env.TAG_TYPE }} ${{ env.TAG_NAME }}
 
     - name: Upload Release Apk
       if: contains(github.ref, 'refs/tags/')
@@ -92,8 +95,8 @@ jobs:
         TAG_NAME: ${{ steps.tag_name.outputs.TAG }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./andbible-beta-${{ env.TAG_NAME }}.apk
-        asset_name: andbible-beta-${{ env.TAG_NAME }}.apk
+        asset_path: ./andbible-${{ env.TAG_NAME }}.apk
+        asset_name: andbible-${{ env.TAG_NAME }}.apk
         asset_content_type: application/vnd.android.package-archive
 
     - name: Before saving cache

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,31 +24,24 @@ jobs:
         # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0
         node-version: 10.x
 
-    - run: mkdir testModules
-
-    - name: Get modules from cache if exists
-      id: cache-modules
-      uses: actions/cache@v2
-      with:
-        path: testModules
-        key: ${{ runner.os }}-modules
-
-    - name: Cache gradle dependencies etc
+    - name: Cache gradle dependencies, test modules etc
+      id: cache
       uses: actions/cache@v2
       with:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
           ~/.android/build-cache
-        key: ${{ runner.os }}-gradle-caches
+          ~/.sword
+        key: ${{ runner.os }}-cache-20200615 # cache auto-removes if not accessed in 7 days. If data needs to refresh, change key name here (till https://github.com/actions/cache/issues/2 is addressed)
 
     - name: Download test modules if not cached
-      if: steps.cache-modules.outputs.cache-hit != 'true'
-      run: wget ${{ secrets.DOWNLOAD_TEST_MODULES_PATH }} -O ./testModules/testmods.zip.enc
-
-    - run: openssl enc -in ./testModules/testmods.zip.enc -out ./testmods.zip -d -aes-256-cbc -pbkdf2 -pass 'pass:${{ secrets.TEST_MODULE_KEY }}'
-    - run: mkdir -p $HOME/.sword
-    - run: unzip -o -d $HOME/.sword ./testmods.zip
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        wget ${{ secrets.DOWNLOAD_TEST_MODULES_PATH }} -O ./testmods.zip.enc
+        openssl enc -in ./testmods.zip.enc -out ./testmods.zip -d -aes-256-cbc -pbkdf2 -pass 'pass:${{ secrets.TEST_MODULE_KEY }}'
+        mkdir -p $HOME/.sword
+        unzip -o -d $HOME/.sword ./testmods.zip
 
     - name: Build with Gradle
       run: ./gradlew --console plain build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,20 +13,33 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 1.8
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
-    - name: Setup Node.js environment
-      uses: actions/setup-node@v1.4.2
+        java-version: 1.8 # later versions not working with roboelectric as of 2020-06-15
+
+    - name: Set up Node.js environment
+      uses: actions/setup-node@v2-beta # v2-beta adds cacheing
       with:
         # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0
         node-version: 10.x
-    
-    #- name: Setup sword test modules
-    - run: openssl enc -in ./testTools/testmods.zip.enc -out testmods.zip -d -aes-256-cbc -pbkdf2 -pass 'pass:${{ secrets.TEST_MODULE_KEY }}'
+
+    - run: mkdir testModules
+
+    - name: Get modules from cache if exists
+      id: cache
+      uses: actions/cache@v2
+      with:
+        path: testModules
+        key: ${{ runner.os }}-modules
+
+    - name: Download modules if not cached
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: wget ${{ secrets.DOWNLOAD_TEST_MODULES_PATH }} -O ./testModules/testmods.zip.enc
+
+    - run: openssl enc -in ./testModules/testmods.zip.enc -out ./testmods.zip -d -aes-256-cbc -pbkdf2 -pass 'pass:${{ secrets.TEST_MODULE_KEY }}'
     - run: mkdir -p $HOME/.sword
-    - run: unzip -o -d $HOME/.sword testmods.zip
-    
+    - run: unzip -o -d $HOME/.sword ./testmods.zip
+
     - name: Build with Gradle
       run: ./gradlew --console plain build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,32 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v1.4.2
+      with:
+        # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0
+        node-version: 10.x
+    
+    #- name: Setup sword test modules
+    - run: openssl enc -in ./testTools/testmods.zip.enc -out testmods.zip -d -aes-256-cbc -pbkdf2 -pass 'pass:${{ secrets.TEST_MODULE_KEY }}'
+    - run: mkdir -p $HOME/.sword
+    - run: unzip -o -d $HOME/.sword testmods.zip
+    
+    - name: Build with Gradle
+      run: ./gradlew --console plain build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,6 +3,7 @@ name: Android CI
 on:
   push:
     branches: [ master ]
+    tags: [ build-* ]
   pull_request:
     branches: [ master ]
 
@@ -50,6 +51,50 @@ jobs:
 
     - name: Build with Gradle
       run: ./gradlew --console plain build
+
+    # Test complete, create apk etc
+
+    - name: Get tag name
+      id: tag_name
+      run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+
+    - name: Create apk release file
+      if: contains(github.ref, 'refs/tags/')
+      run: ./gradlew assembleRelease
+
+    - name: Sign apk
+      if: contains(github.ref, 'refs/tags/')
+      env: 
+        TAG_NAME: ${{ steps.tag_name.outputs.TAG }}
+      working-directory: ./app/build/outputs/apk/release
+      run: |
+        $ANDROID_HOME/build-tools/29.0.3/zipalign -v -p 4 app-release-unsigned.apk app-release-unsigned-aligned.apk
+        echo ${{ secrets.JKS_BASE64 }} | base64 --decode > keystore.jks
+        $ANDROID_HOME/build-tools/29.0.3/apksigner sign --ks keystore.jks --ks-pass 'pass:${{ secrets.KEYSTORE_PASS }}' --key-pass 'pass:${{ secrets.KEY_PASS }}' --out $GITHUB_WORKSPACE/andbible-beta-$TAG_NAME.apk app-release-unsigned-aligned.apk
+        rm -f keystore.jks
+
+    - name: Create release
+      if: contains(github.ref, 'refs/tags/')
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG_NAME: ${{ steps.tag_name.outputs.TAG }}
+      with:
+        tag_name: ${{ env.TAG_NAME }}
+        release_name: Beta ${{ env.TAG_NAME }}
+
+    - name: Upload Release Apk
+      if: contains(github.ref, 'refs/tags/')
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG_NAME: ${{ steps.tag_name.outputs.TAG }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./andbible-beta-${{ env.TAG_NAME }}.apk
+        asset_name: andbible-beta-${{ env.TAG_NAME }}.apk
+        asset_content_type: application/vnd.android.package-archive
 
     - name: Before saving cache
       run: |


### PR DESCRIPTION
**Describe the pull request content**
This would make Github actions do what TravisCI is currently doing.

1. This would also require adding repo secret named TEST_MODULE_KEY with the openssl decryption key.
2. Also requires adding secret named DOWNLOAD_TEST_MODULES_PATH with path to encrypted modules file.

You can check how this works, here: https://github.com/timbze/and-bible/actions

Encrypt the modules on linux like this: 
`openssl enc -in testmods.zip -out testmods.zip.enc -e -aes-256-cbc -pbkdf2 -pass 'pass:TEST_MODULE_KEY'`

**Possible negative side effects?**
~~testmods.zip.enc file is 21mb, which all developers would have an additional 21mb storage in use. Possible change would be to add the file on andbible html repo (or another one) and download from there.~~ Updated yml to download from specified http(s) directory.

**Part 2 - Create release for tags**
Whenever a tag is pushed that beings with build- , it will auto build and sign apk, create beta release and attach the apk.

_This could be done in 2 ways:_
**Current way:** With "if" conditions for the steps that are about release, to make sure if the push is a tag
**Another possible way:** Add another job, for example, we have "build" job now. We could put the first job as "test", and add a second job "release" that would only run if push is a tag AND first job succeeded. However, each job has to set up everything, so that means quite a bit of the code would have to duplicate on job "release"

Requirements
Repo secrets:
JKS_BASE64 (create text with openssl base64 -A -in keystorefile.jks)
KEYSTORE_PASS
KEY_PASS

Related: #688 (maybe I can continue enhancement once this is up and running well)