### PR TITLE
Bug fixes for backing up on Android 11

### DIFF
--- a/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
+++ b/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
@@ -303,8 +303,13 @@ class BackupControl @Inject constructor() {
     companion object {
 
         // this is now unused because And Bible databases are held on the SD card to facilitate easier backup by file copy
-        private val internalDbDir = File(Environment.getDataDirectory(), "/data/" + SharedConstants.PACKAGE_NAME + "/databases/")
-        private val internalDbBackupDir = File(Environment.getDataDirectory(), "/data/" + SharedConstants.PACKAGE_NAME + "/files/backup")
+        private lateinit var internalDbDir : File;
+        private lateinit var internalDbBackupDir: File;
+
+        fun setupDirs(context: Context) {
+            internalDbDir = File(context.getDatabasePath(DATABASE_NAME).parent!!)
+            internalDbBackupDir = File(context.filesDir,  "/backup")
+        }
 
         private val TAG = "BackupControl"
     }

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -213,6 +213,9 @@ class MainBibleActivity : CustomTitlebarActivityBase(), VerseActionModeMediator.
             .mainBibleActivityModule(MainBibleActivityModule(this))
             .build()
             .inject(this)
+
+        // use context to setup backup control dirs
+        BackupControl.setupDirs(this)
         // When I mess up database, I can re-create database like this.
         //backupControl.resetDatabase()
 


### PR DESCRIPTION
I was trying out this app and found that it crashed in Android 11 when trying to backup the modules or app db when using the share button (i.e. via Intent). I figured I'd take a stab at trying to fix this bug.

This is similar to #636, but does not fix that bug, as I did not use the phone storage option.

I don't have much experience working with Android. Any feedback is appreciated. 👍 

The root of the problem seems to be that Android 11 changes the internal path structure of Android apps.
The internal path structure now looks like `/data/user/0/<PACKAGE_NAME>` instead of `/data/data/<PACKAGE_NAME>`
The solution I came up with was to grab the app's storage location from the app's Context, passing it into BackupControl in the onCreate function when the app is started.  Using this, I was able to 
briefly test out the fixes on 3 devices, one on Android 7, one on Android 10, and one on Android 11, and all 3 seemed to work fine after the changes I made. 

Closes #739 


