### PR TITLE
Fixes issue so users on Android 10+ can backup to locations other than just phone storage

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.kt
@@ -216,30 +216,30 @@ constructor(private val callingActivity: MainBibleActivity,
                     d.findViewById<TextView>(android.R.id.message)!!.movementMethod = LinkMovementMethod.getInstance()
                 }
                 R.id.backup_app_database -> {
-                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-                        AlertDialog.Builder(callingActivity)
-                            .setTitle(callingActivity.getString(R.string.backup_backup_title))
-                            .setMessage(callingActivity.getString(R.string.backup_backup_message))
-                            .setNegativeButton(callingActivity.getString(R.string.backup_phone_storage)) { dialog, which ->
+                    AlertDialog.Builder(callingActivity)
+                        .setTitle(callingActivity.getString(R.string.backup_backup_title))
+                        .setMessage(callingActivity.getString(R.string.backup_backup_message))
+                        .setNegativeButton(callingActivity.getString(R.string.backup_phone_storage)) { dialog, which ->
+                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                                 if (ContextCompat.checkSelfPermission(callingActivity, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED) {
                                     ActivityCompat.requestPermissions(callingActivity, arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE), BACKUP_SAVE_REQUEST)
                                 } else {
                                     backupControl.backupDatabase()
                                 }
+                            } else {
+                                val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+                                    addCategory(Intent.CATEGORY_OPENABLE)
+                                    type = "application/x-sqlite3"
+                                    putExtra(Intent.EXTRA_TITLE, DATABASE_NAME)
+                                }
+                                callingActivity.startActivityForResult(intent, REQUEST_PICK_FILE_FOR_BACKUP_DB)
                             }
-                            .setPositiveButton(callingActivity.getString(R.string.backup_share)) { dialog, which ->
-                                backupControl.backupDatabaseViaSendIntent(callingActivity)
-                            }
-                            .setNeutralButton(callingActivity.getString(R.string.cancel), null)
-                            .show()
-                    } else {
-                        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                            addCategory(Intent.CATEGORY_OPENABLE)
-                            type = "application/x-sqlite3"
-                            putExtra(Intent.EXTRA_TITLE, DATABASE_NAME)
                         }
-                        callingActivity.startActivityForResult(intent, REQUEST_PICK_FILE_FOR_BACKUP_DB)
-                    }
+                        .setPositiveButton(callingActivity.getString(R.string.backup_share)) { dialog, which ->
+                            backupControl.backupDatabaseViaSendIntent(callingActivity)
+                        }
+                        .setNeutralButton(callingActivity.getString(R.string.cancel), null)
+                        .show()
                     isHandled = true
                 }
                 R.id.backup_modules -> {


### PR DESCRIPTION
A small change... Just moved an if statement... 😄 

This change allows users on Android 10+ devices to backup database to locations other than just their phone storage.

Related #756 

I think for 3.4, I would add the same two options when backing up modules, so once users have chosen which modules to back up, they would see two options: 
 - save to phone storage (use system file picker to save file offline)
 - share (which is currently the default/only option) (used for online sharing)


…

**Describe the pull request content**
A clear and concise description of what the pull request is about.
What are the benefits of this new code addition? 
Possible negative side effects? 

**Screenshots**
If applicable, add screenshots to help explain your pull request.
