### PR TITLE
Handle alerts properly when user clicks outside alert area or pushes back button

### DIFF
--- a/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
+++ b/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
@@ -214,6 +214,7 @@ class BackupControl @Inject constructor() {
                     }
                     .setNeutralButton(R.string.select_all) { _, _ -> it.resume(null) }
                     .setNegativeButton(R.string.cancel) { _, _ -> it.resume(null) }
+                    .setOnCancelListener {_ -> it.resume(null)}
                     .setTitle(getString(R.string.backup_modules_title))
                     .create()
 

--- a/app/src/main/java/net/bible/android/control/page/window/WindowControl.kt
+++ b/app/src/main/java/net/bible/android/control/page/window/WindowControl.kt
@@ -331,6 +331,7 @@ open class WindowControl @Inject constructor(
             }
             .setNeutralButton(R.string.select_all) { _, _ ->  it.resume(null) }
             .setNegativeButton(R.string.cancel) { _, _ -> it.resume(null)}
+            .setOnCancelListener {_ -> it.resume(null)}
             .setTitle(context.getString(R.string.copy_settings_title))
             .create()
 

--- a/app/src/main/java/net/bible/android/view/activity/download/DownloadActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/download/DownloadActivity.kt
@@ -106,6 +106,7 @@ open class DownloadActivity : DocumentSelectionBase(NO_OPTIONS_MENU, R.menu.down
                         it.resume(true)
                     }
                     .setNeutralButton(R.string.cancel) {_, _ -> it.resume(false)}
+                    .setOnCancelListener {_ -> it.resume(false)}
                     .show()
             }
     }

--- a/app/src/main/java/net/bible/android/view/activity/installzip/InstallZip.kt
+++ b/app/src/main/java/net/bible/android/view/activity/installzip/InstallZip.kt
@@ -187,6 +187,7 @@ class ZipHandler(
                     .setMessage(activity.getString(R.string.overwrite_files, "\n" + e.files.joinToString("\n")))
                     .setPositiveButton(R.string.yes) {_, _ -> it.resume(true)}
                     .setNeutralButton(R.string.cancel) {_, _ -> it.resume(false)}
+                    .setOnCancelListener {_ -> it.resume(false)}
                     .show()
             }
             if(doInstall) R_OK else R_CANCEL

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -416,6 +416,7 @@ class MainBibleActivity : CustomTitlebarActivityBase(), VerseActionModeMediator.
                     preferences.edit().putString("beta-notice-displayed", ver).apply()
                     it.resume(true)
                 }
+                .setOnCancelListener {_ -> it.resume(false)}
                 .create()
             d.show()
             d.findViewById<TextView>(android.R.id.message)!!.movementMethod = LinkMovementMethod.getInstance()


### PR DESCRIPTION
This handles some edge cases on alert dialogs. Some dialogs did not handle the case when a user hits the back button or clicks the area around/behind the dialog. If the dialog was in a co-routine, this lead to the co-routine never resuming, and the activity may appear "stuck"

For example, if a user happened to click the area around/behind an alert, or pushes the phone's back button, when seeing the download warning, the user would see a download loading spinner forever, as they never explicitly allowed or denied downloads. This fixes this case by associating an outside click/back button action as the same as hitting the negative button.

I searched through the whole code base and these are the 5 I thought where we may need to handle these cases, as they were all in suspend functions/co-routines

**Describe the pull request content**
A clear and concise description of what the pull request is about.
What are the benefits of this new code addition? 
Possible negative side effects? 

**Screenshots**
If applicable, add screenshots to help explain your pull request.
