### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 10 # so that recent tags can be found
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ def getGitHash = { ->
 def getGitDescribe = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe'
+        commandLine 'git', 'describe', '--always'
         standardOutput = stdout
     }
     return stdout.toString().trim()


### PR DESCRIPTION
1. Add `--always` parameter to `git describe` so that it does not throw error when no tag is found in fetched commits
2. Fetch 10 latest commits in CI instead of just 1