### PR TITLE
Closes #825 - Autofocus keyboard in find activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,7 +75,7 @@
             android:configChanges="keyboardHidden|orientation|screenSize|locale"
             android:label="@string/search"
             android:parentActivityName="net.bible.android.view.activity.page.MainBibleActivity"
-            android:windowSoftInputMode="adjustResize|adjustPan"/>
+            android:windowSoftInputMode="adjustResize"/>
         <activity
             android:name="net.bible.android.view.activity.search.SearchResults"
             android:theme="@style/Theme.AppCompat.DayNight.Dialog.Alert"

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -188,6 +188,7 @@ class MainBibleActivity : CustomTitlebarActivityBase(), VerseActionModeMediator.
     // Bottom offset with navigation bar and transport bar
     val bottomOffset2 get() = bottomOffset1 + if (transportBarVisible) transportBarHeight else 0
 
+    private var isPaused = false
     /**
      * return percentage scrolled down page
      */
@@ -224,25 +225,27 @@ class MainBibleActivity : CustomTitlebarActivityBase(), VerseActionModeMediator.
         var firstTime = true
 
         ViewCompat.setOnApplyWindowInsetsListener(window.decorView) { view, insets: WindowInsetsCompat ->
-            val heightChanged =
-                bottomOffset1 != insets.systemWindowInsetBottom || topOffset1 != insets.systemWindowInsetTop
-            val widthChanged =
-                leftOffset1 != insets.systemWindowInsetLeft || rightOffset1 != insets.systemWindowInsetRight
-            bottomOffset1 = insets.systemWindowInsetBottom
-            topOffset1 = insets.systemWindowInsetTop
-            leftOffset1 = insets.systemWindowInsetLeft
-            rightOffset1 = insets.systemWindowInsetRight
-            Log.d(TAG, "onApplyWindowInsets $bottomOffset1 $topOffset1 $leftOffset1 $rightOffset1")
+            if (!isPaused) {
+                val heightChanged =
+                    bottomOffset1 != insets.systemWindowInsetBottom || topOffset1 != insets.systemWindowInsetTop
+                val widthChanged =
+                    leftOffset1 != insets.systemWindowInsetLeft || rightOffset1 != insets.systemWindowInsetRight
+                bottomOffset1 = insets.systemWindowInsetBottom
+                topOffset1 = insets.systemWindowInsetTop
+                leftOffset1 = insets.systemWindowInsetLeft
+                rightOffset1 = insets.systemWindowInsetRight
+                Log.d(TAG, "onApplyWindowInsets $bottomOffset1 $topOffset1 $leftOffset1 $rightOffset1")
 
-            if(firstTime) {
-                postInitialize()
+                if (firstTime) {
+                    postInitialize()
+                }
+
+                if (widthChanged || heightChanged)
+                    displaySizeChanged(firstTime)
+
+                if (firstTime)
+                    firstTime = false
             }
-
-            if (widthChanged || heightChanged)
-                displaySizeChanged(firstTime)
-
-            if(firstTime)
-                firstTime = false
 
             ViewCompat.onApplyWindowInsets(view, insets)
         }
@@ -471,6 +474,7 @@ class MainBibleActivity : CustomTitlebarActivityBase(), VerseActionModeMediator.
 
     override fun onPause() {
         fullScreen = false;
+        isPaused = true;
         super.onPause()
     }
 
@@ -1357,6 +1361,7 @@ class MainBibleActivity : CustomTitlebarActivityBase(), VerseActionModeMediator.
 
     override fun onResume() {
         super.onResume()
+        isPaused = false
         // allow webView to start monitoring tilt by setting focus which causes tilt-scroll to resume
         documentViewManager.documentView?.asView()?.requestFocus()
     }

--- a/app/src/main/java/net/bible/android/view/activity/search/Search.kt
+++ b/app/src/main/java/net/bible/android/view/activity/search/Search.kt
@@ -178,6 +178,11 @@ class Search : CustomTitlebarActivityBase(R.menu.search_actionbar_menu) {
         return false
     }
 
+    override fun onResume() {
+        super.onResume()
+        searchText.requestFocus()
+    }
+
     fun onRebuildIndex(v: View?) {
         startActivity(Intent(this, SearchIndex::class.java))
         finish()

--- a/app/src/main/res/layout/search.xml
+++ b/app/src/main/res/layout/search.xml
@@ -117,11 +117,6 @@
 				android:onClick="onRebuildIndex"
 				android:layout_weight="2"
 				/>
-
-			<View
-				android:layout_width="0dip"
-				android:layout_height="match_parent"
-				android:layout_weight="1"/>
 	
 			<Button android:id="@+id/submit"
 				android:text="@string/search"


### PR DESCRIPTION
# Description
Closes #825 

When opening search, keyboard is auto-focused.

Also fixed the positioning of the 3 buttons

Before (when clicking find from the menu)
![Screenshot_20200903-081251](https://user-images.githubusercontent.com/8870594/92132971-10895f80-edc5-11ea-9583-703d7ed75b69.png)

After (when clicking find from the menu)
![Screenshot_20200903-083826](https://user-images.githubusercontent.com/8870594/92132962-0d8e6f00-edc5-11ea-9ca2-71a6b0627b1e.png)

# Issues
- [x] Currently the only issue is when backing out of find, the pinned window buttons animate and zoom from centre of the screen to the bottom 


