### PR TITLE
Closes #832 - Window buttons jump when coming back from find

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/base/ActivityBase.kt
+++ b/app/src/main/java/net/bible/android/view/activity/base/ActivityBase.kt
@@ -227,7 +227,7 @@ abstract class ActivityBase : AppCompatActivity(), AndBibleActivity {
             val inputMethodManager: InputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
             inputMethodManager.hideSoftInputFromWindow(currentFocus!!.windowToken, 0)
         } catch (e: Exception) {
-            Log.e("AndroidView", "closeKeyboard: $e")
+            Log.e(TAG, "closeKeyboard: $e")
         }
     }
 

--- a/app/src/main/java/net/bible/android/view/activity/base/ActivityBase.kt
+++ b/app/src/main/java/net/bible/android/view/activity/base/ActivityBase.kt
@@ -28,6 +28,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.KeyEvent
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatDelegate
 
 import net.bible.android.view.util.locale.LocaleHelper
@@ -216,6 +217,17 @@ abstract class ActivityBase : AppCompatActivity(), AndBibleActivity {
         Log.i(localClassName, "onPause:" + this)
         if (isScreenOn && !ScreenSettings.isScreenOn) {
             onScreenTurnedOff()
+        }
+        closeKeyboard()
+    }
+
+
+    private fun closeKeyboard() {
+        try {
+            val inputMethodManager: InputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            inputMethodManager.hideSoftInputFromWindow(currentFocus!!.windowToken, 0)
+        } catch (e: Exception) {
+            Log.e("AndroidView", "closeKeyboard: $e")
         }
     }
 

--- a/app/src/main/java/net/bible/android/view/activity/search/Search.kt
+++ b/app/src/main/java/net/bible/android/view/activity/search/Search.kt
@@ -20,14 +20,12 @@ package net.bible.android.view.activity.search
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.EditorInfo
-import android.view.inputmethod.InputMethodManager
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import kotlinx.android.synthetic.main.search.*
@@ -183,20 +181,6 @@ class Search : CustomTitlebarActivityBase(R.menu.search_actionbar_menu) {
         searchText.requestFocus()
     }
 
-
-    override fun onPause() {
-        super.onPause()
-        closeKeyboard()
-    }
-
-    private fun closeKeyboard() {
-        try {
-            val inputMethodManager: InputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            inputMethodManager.hideSoftInputFromWindow(currentFocus!!.windowToken, 0)
-        } catch (e: Exception) {
-            Log.e("AndroidView", "closeKeyboard: $e")
-        }
-    }
 
     fun onRebuildIndex(v: View?) {
         startActivity(Intent(this, SearchIndex::class.java))

--- a/app/src/main/java/net/bible/android/view/activity/search/Search.kt
+++ b/app/src/main/java/net/bible/android/view/activity/search/Search.kt
@@ -20,12 +20,14 @@ package net.bible.android.view.activity.search
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import kotlinx.android.synthetic.main.search.*
@@ -179,6 +181,21 @@ class Search : CustomTitlebarActivityBase(R.menu.search_actionbar_menu) {
     override fun onResume() {
         super.onResume()
         searchText.requestFocus()
+    }
+
+
+    override fun onPause() {
+        super.onPause()
+        closeKeyboard()
+    }
+
+    private fun closeKeyboard() {
+        try {
+            val inputMethodManager: InputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            inputMethodManager.hideSoftInputFromWindow(currentFocus!!.windowToken, 0)
+        } catch (e: Exception) {
+            Log.e("AndroidView", "closeKeyboard: $e")
+        }
     }
 
     fun onRebuildIndex(v: View?) {


### PR DESCRIPTION
Closes #832 

Added a method to close the keyboard before exiting the find activity so a
resize event is not triggered in the main activity, which prevents the window
buttons from jumping.


