### PR TITLE
Enable Strong's pop up by long pressing the word (initial prototype for comment)

### DIFF
--- a/app/src/main/assets/web/style.css
+++ b/app/src/main/assets/web/style.css
@@ -106,11 +106,15 @@ h1 a, .heading2, .heading3, .heading4 {
 	vertical-align: bottom;
 	font-size: 0.7em;
 }
+.wordlink {
+	color: #101010;
+	text-decoration: none;
+}
 .strongs {
 	color: #669999;
 	font-size: 0.7em;
 	vertical-align: sub;
-	text-decoration: none
+	text-decoration: none;
 }
 .redLetter {
 	color: #800;

--- a/app/src/main/java/net/bible/service/format/osistohtml/strongs/StrongsUtil.java
+++ b/app/src/main/java/net/bible/service/format/osistohtml/strongs/StrongsUtil.java
@@ -40,27 +40,27 @@ public class StrongsUtil {
 	}
 	
 	public static String createStrongsLink(String protocol, String strongsNumber, String content, String cssClass) {
-		// pad with leading zeros to 5 characters
+
+		// create opening tag for Strong's link
+		// descriptive string
+		// link closing tag
+		return String.format("%s%s%s", createStrongsLinkOpenTag(protocol, strongsNumber, cssClass), content, createStrongsLinkCloseTag());
+	}
+
+	public static String createStrongsLinkOpenTag(String protocol, String strongsNumber) {
+		return createStrongsLinkOpenTag(protocol, strongsNumber, DEFAULT_CSS_CLASS);
+	}
+
+	public static String createStrongsLinkOpenTag(String protocol, String strongsNumber, String cssClass) {
 		String paddedRef = StringUtils.leftPad(strongsNumber, 5, "0");
 
-		StringBuilder tag = new StringBuilder();
-		// create opening tag for Strong's link
-		tag.append("<a href='");
-
 		// calculate uri e.g. H:01234
-		tag.append(protocol).append(":").append(paddedRef);
-
 		// set css class
-		tag.append("' class='"+cssClass+"'>");
+		return String.format("<a href='%s:%s' class='%s'>", protocol, paddedRef, cssClass);
+	}
 
-		// descriptive string
-		tag.append(content);
-
-		// link closing tag
-		tag.append("</a>");
-		
-		String strTag = tag.toString();
-		return strTag;
+	public static String createStrongsLinkCloseTag() {
+		return "</a>";
 	}
 
 	public static String getStrongsProtocol(String ref) {


### PR DESCRIPTION
**Describe the pull request content**
Add Strongs links around the words they represent, this is available with or without the Strongs numbers in the text. This is an initial prototype of the feature to demonstrate what it could look like.

The Sword text parser for Strongs tags is modified to wrap the words with HTML link, exactly as they are wrapped by the OSIS tags in the original markup. The feature to show Strongs numbers to the right of the word is as it was before.

Should this feature be enabled by default or an optional feature that can be disabled via config? I can do either, just need to understand the code base a bit better and work out how to add the config option... if it should be a config option.

I'm new to Android App development, so haven't yet worked out where the unit tests are, or how to run them. I'll try and add unit tests if there are already unit tests for this area.

Should this area of the code be converted to Kotlin before adding the feature? If so, that's fine... I just need to learn Kotlin first ;)

Closes #177 