### PR TITLE
Allow any workspace to be deleted at any time, except if it is the only one.

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/workspaces/WorkspaceSelectorActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/workspaces/WorkspaceSelectorActivity.kt
@@ -465,7 +465,7 @@ class WorkspaceSelectorActivity: ActivityBase() {
         val menu = popup.menu
         popup.menuInflater.inflate(R.menu.workspace_popup_menu, menu)
         val delItem = menu.findItem(R.id.deleteWorkspace)
-        delItem.isEnabled = workspaceEntity.id != windowControl.windowRepository.id
+        delItem.isEnabled = dataSet.size != 1 // cannot delete the only workspace
         popup.show()
     }
 

--- a/app/src/main/java/net/bible/android/view/activity/workspaces/WorkspaceSelectorActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/workspaces/WorkspaceSelectorActivity.kt
@@ -465,7 +465,7 @@ class WorkspaceSelectorActivity: ActivityBase() {
         val menu = popup.menu
         popup.menuInflater.inflate(R.menu.workspace_popup_menu, menu)
         val delItem = menu.findItem(R.id.deleteWorkspace)
-        delItem.isEnabled = dataSet.size != 1 // cannot delete the only workspace
+        delItem.isEnabled = dataSet.size > 1 // cannot delete the only workspace
         popup.show()
     }
 


### PR DESCRIPTION
Closes #836. 

It seems to respond correctly if deleting the active workspace already by switching to another workspace on save. Just changed the delete menu item to be disabled if it's the only workspace, as I'm not sure what would happen then?

**Describe the pull request content**
A clear and concise description of what the pull request is about.
What are the benefits of this new code addition? 
Possible negative side effects? 

**Screenshots**
If applicable, add screenshots to help explain your pull request.
