### PR TITLE
Add application preference to make it possible to disable reference overlay in fullscreen

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/screen/SplitBibleArea.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/screen/SplitBibleArea.kt
@@ -553,6 +553,9 @@ class SplitBibleArea(
         }
 
     private fun updateBibleReferenceOverlay(_show: Boolean) {
+        val isSettingDisabled = CommonUtils.sharedPreferences.getBoolean("hide_bible_reference_overlay", false)
+        if (isSettingDisabled) return
+
         val show = mainBibleActivity.fullScreen && _show
         if(show) {
             bibleReferenceOverlay.visibility = View.VISIBLE

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,6 +155,8 @@
     <string name="window_pinning_menutitle">Window pinning</string>
     <string name="hide_window_buttons_title">Hide window buttons</string>
     <string name="hide_window_buttons_summary">Window buttons that are displayed on right side of the bible views are hidden. Window navigation bar on the bottom is still displayed and you may open window popup menu by long-clicking them.</string>
+    <string name="hide_bible_reference_overlay_title">Hide Bible reference overlay</string>
+    <string name="hide_bible_reference_overlay_summary">Never show the Bible reference overlay close to the bottom of screen when app is in fullscreen mode</string>
     <string name="font_size_title">Font size</string>
 
     <string name="full_screen_hide_buttons_pref_title">Hide window button bar in fullscreen</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -35,6 +35,11 @@
 			android:summary="@string/hide_window_buttons_summary"
 			android:defaultValue="false"
 			/>
+		<SwitchPreferenceCompat android:key="hide_bible_reference_overlay"
+			android:title="@string/hide_bible_reference_overlay_title"
+			android:summary="@string/hide_bible_reference_overlay_summary"
+			android:defaultValue="false"
+			/>
 		<ListPreference android:key="night_mode_pref3"
 			android:title="@string/prefs_night_mode_title"
 			android:summary="@string/prefs_night_mode_summary"


### PR DESCRIPTION
This PR makes it possible to change a setting in application preferences so that the Bible reference overlay that shows in fullscreen mode will be disabled.

Addresses #310 to some degree