### PR TITLE
Prevent crashing on restoring a window with unknown document

### DIFF
--- a/app/src/main/java/net/bible/android/control/page/CurrentPageManager.kt
+++ b/app/src/main/java/net/bible/android/control/page/CurrentPageManager.kt
@@ -252,7 +252,14 @@ open class CurrentPageManager @Inject constructor(
         val restoredBookCategory = try {
             DocumentCategory.valueOf(pageManagerEntity.currentCategoryName)
         } catch (e: IllegalArgumentException) {
-            BookCategory.fromString(pageManagerEntity.currentCategoryName).documentCategory
+            try {
+                BookCategory.fromString(pageManagerEntity.currentCategoryName).documentCategory
+            } catch (e: RuntimeException) {
+                val name = pageManagerEntity.currentCategoryName
+                Log.d("Error","Cannot load document category: $name")
+                e.printStackTrace()
+                DocumentCategory.GENERAL_BOOK
+            }
         }
         val settings = pageManagerEntity.textDisplaySettings
         if(workspaceDisplaySettings != null) {

--- a/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
+++ b/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
@@ -34,6 +34,7 @@ import net.bible.android.view.activity.base.SharedActivityState
 import net.bible.service.common.CommonUtils.getResourceString
 import net.bible.service.history.HistoryManager
 import org.crosswire.jsword.versification.BookName
+import java.lang.RuntimeException
 import javax.inject.Inject
 import javax.inject.Provider
 import kotlin.math.min


### PR DESCRIPTION
If documentCategory was "Other" in the database, restoring would crash the application.
Now it will just set another document type for the window.