### PR TITLE
Draft: Fix crash when displaying a bookmark with endOffset too high

### DIFF
--- a/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.kt
+++ b/app/src/main/java/net/bible/android/control/bookmark/BookmarkControl.kt
@@ -235,6 +235,7 @@ open class BookmarkControl @Inject constructor(
         val startOffset = b.startOffset ?: 0
         var startVerse = verseTexts.first()
         var endOffset = b.endOffset ?: startVerse.length
+        if (endOffset >= startVerse.length) endOffset = startVerse.length
         if(verseTexts.size == 1) {
             b.text = startVerse.slice(startOffset until endOffset)
         } else if(verseTexts.size > 1) {


### PR DESCRIPTION
This is a quick fix, we need to debug why a bookmark was created with an endOffset of 1 higher than the verse lenght.

Also, I should probably make it > instead of >=