### PR TITLE
Add user setting on what to do with Bible/commentary button click

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,10 +2,16 @@ name: Android CI
 
 on:
   push:
-    branches: [ develop, current-stable, release/* ]
-    tags: [ build-*, alpha-*, beta-*, production-* ]
+    branches: 
+      - develop
+      - 'current-stable'
+      - 'release/*'
+    tags: 
+      - 'build-*'
+      - 'alpha-*'
+      - 'beta-*'
+      - 'production-*'
   pull_request:
-    branches: [ develop, current-stable ]
 
 jobs:
   build:

--- a/app/src/main/java/net/bible/android/control/document/DocumentControl.kt
+++ b/app/src/main/java/net/bible/android/control/document/DocumentControl.kt
@@ -107,6 +107,29 @@ class DocumentControl @Inject constructor(
     val currentDocument: Book?
         get () = activeWindowPageManagerProvider.activeWindowPageManager.currentPage.currentDocument
 
+    val suggestedBible: Book?
+        get() {
+            val currentPageManager = activeWindowPageManagerProvider.activeWindowPageManager
+            val currentBible = currentPageManager.currentBible.currentDocument
+
+            return getSuggestedBook(swordDocumentFacade.bibles, currentBible, bookFilter, currentPageManager.isBibleShown)
+        }
+
+    /** Suggest an alternative commentary to view or return null
+     */
+    // only show commentaries that contain verse - extra checks for TDavid because it always returns true
+    // book claims to contain the verse but
+    // TDavid has a flawed index and incorrectly claims to contain contents for all books of the
+    // bible so only return true if !TDavid or is Psalms
+    val suggestedCommentary: Book?
+        get() {
+            val currentPageManager = activeWindowPageManagerProvider.activeWindowPageManager
+            val currentCommentary = currentPageManager.currentCommentary.currentDocument
+
+            return getSuggestedBook(swordDocumentFacade.getBooks(BookCategory.COMMENTARY),
+                    currentCommentary, commentaryFilter, currentPageManager.isCommentaryShown)
+        }
+
     /**
      * Possible books will often not include the current verse but most will include chap 1 verse 1
      */

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -180,7 +180,8 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
     // Bottom offset with navigation bar and transport bar and window buttons
     val bottomOffset3 get() = bottomOffset2 + if (restoreButtonsVisible) windowButtonHeight else 0
 
-    private val restoreButtonsVisible get() = CommonUtils.sharedPreferences.getBoolean("restoreButtonsVisible", false)
+    private val preferences = CommonUtils.sharedPreferences
+    private val restoreButtonsVisible get() = preferences.getBoolean("restoreButtonsVisible", false)
 
     private var isPaused = false
     /**
@@ -624,8 +625,6 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
         }
     }
 
-    private val preferences = CommonUtils.sharedPreferences
-
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.main_bible_options_menu, menu)
 
@@ -759,11 +758,15 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
     }
 
     private val currentDocument get() = windowControl.activeWindow.pageManager.currentPage.currentDocument
+    private val toolbarButtonSetting get() = preferences.getString("toolbar_button_actions", "default")
 
     override fun updateActions() {
         updateTitle()
         val biblesForVerse = documentControl.biblesForVerse.filter {currentDocument != it}
         val commentariesForVerse = documentControl.commentariesForVerse.filter {currentDocument != it}
+
+        val suggestedBible = documentControl.suggestedBible
+        val suggestedCommentary = documentControl.suggestedCommentary
 
         var visibleButtonCount = 0
         val screenWidth = resources.displayMetrics.widthPixels
@@ -772,27 +775,59 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
         val maxButtons: Int = (maxWidth / approximateSize).toInt()
         val showSearch = documentControl.isBibleBook || documentControl.isCommentary
 
+        fun shouldShowBibleButton(): Boolean =
+            toolbarButtonSetting?.let {
+                (it.contains("swap-") && suggestedBible != null) ||
+                    (!it.contains("swap-") && biblesForVerse.isNotEmpty())
+            } ?: false
+
+
+        fun shouldShowCommentaryButton(): Boolean =
+            toolbarButtonSetting?.let {
+                (it.contains("swap-") && suggestedCommentary != null) ||
+                    (!it.contains("swap-") && commentariesForVerse.isNotEmpty())
+            } ?: false
+
+        fun bibleClick(view: View) {
+            if (toolbarButtonSetting?.contains("swap-") == true)
+                setCurrentDocument(documentControl.suggestedBible);
+            else
+                menuForDocs(view, biblesForVerse)
+        }
+
+        fun commentaryClick(view: View) {
+            if (toolbarButtonSetting?.contains("swap-") == true)
+                setCurrentDocument(documentControl.suggestedCommentary);
+            else
+                menuForDocs(view, commentariesForVerse)
+        }
+
+        fun bibleLongPress(view: View) {
+            if (toolbarButtonSetting?.contains("swap-menu") == true)
+                menuForDocs(view, biblesForVerse)
+            else {
+                startDocumentChooser("BIBLE")
+            }
+        }
+
+        fun commentaryLongPress(view: View) {
+            if (toolbarButtonSetting?.contains("swap-menu") == true)
+                menuForDocs(view, commentariesForVerse)
+            else
+                startDocumentChooser("COMMENTARY")
+        }
+
         binding.apply {
-            bibleButton.visibility = if (visibleButtonCount < maxButtons && biblesForVerse.isNotEmpty()) {
-                bibleButton.setOnClickListener { menuForDocs(it, biblesForVerse) }
-                bibleButton.setOnLongClickListener {
-                    val intent = Intent(this@MainBibleActivity, ChooseDocument::class.java)
-                    intent.putExtra("type", "BIBLE")
-                    startActivityForResult(intent, IntentHelper.UPDATE_SUGGESTED_DOCUMENTS_ON_FINISH)
-                    true
-                }
+            bibleButton.visibility = if (visibleButtonCount < maxButtons && shouldShowBibleButton()) {
+                bibleButton.setOnClickListener { bibleClick(it) }
+                bibleButton.setOnLongClickListener { bibleLongPress(it); true }
                 visibleButtonCount += 1
                 View.VISIBLE
             } else View.GONE
 
-            commentaryButton.visibility = if (commentariesForVerse.isNotEmpty() && visibleButtonCount < maxButtons) {
-                commentaryButton.setOnClickListener { menuForDocs(it, commentariesForVerse) }
-                commentaryButton.setOnLongClickListener {
-                    val intent = Intent(this@MainBibleActivity, ChooseDocument::class.java)
-                    intent.putExtra("type", "COMMENTARY")
-                    startActivityForResult(intent, IntentHelper.UPDATE_SUGGESTED_DOCUMENTS_ON_FINISH)
-                    true
-                }
+            commentaryButton.visibility = if (shouldShowCommentaryButton() && visibleButtonCount < maxButtons) {
+                commentaryButton.setOnClickListener { commentaryClick(it) }
+                commentaryButton.setOnLongClickListener { commentaryLongPress(it); true }
                 visibleButtonCount += 1
                 View.VISIBLE
             } else View.GONE
@@ -844,6 +879,13 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
             val btn = navigationView.menu.findItem(R.id.searchButton)
             btn.isEnabled = showSearch
         }
+    }
+
+    /** @param type can be BIBLE or COMMENTARY */
+    private fun startDocumentChooser(type: String) {
+        val intent = Intent(this, ChooseDocument::class.java)
+        intent.putExtra("type", type)
+        startActivityForResult(intent, IntentHelper.UPDATE_SUGGESTED_DOCUMENTS_ON_FINISH)
     }
 
     fun onEventMainThread(passageEvent: CurrentVerseChangedEvent) {

--- a/app/src/main/java/net/bible/android/view/activity/settings/SettingsActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/SettingsActivity.kt
@@ -102,6 +102,11 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val dictCategory = preferenceScreen.findPreference<PreferenceCategory>("dictionaries_category") as PreferenceCategory
         dictCategory.isVisible = showDictionaries
 
+        preferenceScreen.findPreference<ListPreference>("toolbar_button_actions")?.apply {
+                if (value.isNullOrBlank())
+                    value = "default"
+            }
+
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val pref = preferenceScreen.findPreference<ListPreference>("request_sdcard_permission_pref") as Preference
             pref.isVisible = false

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -22,6 +22,19 @@
 		<item>@string/doc_type_addons</item>
 	</string-array>
 
+	<!-- Bible/commentary toolbar button press actions -->
+	<string-array name="prefs_toolbar_button_action_descriptions">
+		<item>@string/prefs_toolbar_button_action_default</item>
+		<item>@string/prefs_toolbar_button_action_swap_menu</item>
+		<item>@string/prefs_toolbar_button_action_swap_activity</item>
+	</string-array>
+	<string-array name="prefs_toolbar_button_action_values">
+		<item>default</item>
+		<item>swap-menu</item>
+		<item>swap-activity</item>
+	</string-array>
+	<!-- Bible/commentary toolbar button press actions -->
+
 	<!-- Screen colors: automatic night mode, day, night -->
 	<string-array name="prefs_night_mode_descriptions">
 		<item>@string/prefs_night_mode_manual</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,13 @@
     <string name="prefs_section_title_title">Section titles</string>
     <string name="prefs_red_letter_title">Red Letter</string>
     <string name="prefs_tilt_to_scroll_title">Tilt to scroll</string>
+
+    <string name="prefs_toolbar_button_action_title">Action for toolbar button press</string>
+    <string name="prefs_toolbar_button_action_summary">Action to take when pressing/long-pressing Bible or Commentary toolbar buttons</string>
+    <string name="prefs_toolbar_button_action_default">Press to open menu, long press for documents screen (default)</string>
+    <string name="prefs_toolbar_button_action_swap_menu">Press to open next document, long press to open menu</string>
+    <string name="prefs_toolbar_button_action_swap_activity">Press to open next document, long press for documents screen</string>
+
     <string name="prefs_night_mode_title">Night mode switching</string>
     <string name="prefs_night_mode_summary">Whether to switch to night mode automatically (if device supports), manually or via system setting (Android 10+).</string>
     <string name="prefs_night_mode_manual">Manual</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -61,6 +61,13 @@
 			android:summary="@string/active_window_indicator_summary"
 			android:defaultValue="true"
 			/>
+
+		<ListPreference android:key="toolbar_button_actions"
+			android:title="@string/prefs_toolbar_button_action_title"
+			android:summary="@string/prefs_toolbar_button_action_summary"
+			android:entries="@array/prefs_toolbar_button_action_descriptions"
+			android:entryValues="@array/prefs_toolbar_button_action_values" />
+
 		<ListPreference android:key="night_mode_pref3"
 			android:title="@string/prefs_night_mode_title"
 			android:summary="@string/prefs_night_mode_summary"


### PR DESCRIPTION
Fixes #597
This branch is based on refactor/kotlin_android_extensions_deprecated -- once that is merged this PR will need to change to dev branch.

### Other
* Changed CI config to run for all PRs, not just develop and current-stable branches

This PR adds the below setting option to application preferences. I'm not sure if the third option is even needed... Edit: on second thought, I think it **should** be there. When user has lots of commentaries he/she might want to open activity by default
![Screenshot_1616792281](https://user-images.githubusercontent.com/35117769/112692852-3a7b9f80-8e45-11eb-9727-f7d1dd56d639.png)
