### PR TITLE
Fix search for some soft keyboards that don't properly send "EditorInfo.IME_ACTION_SEARCH"

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/search/Search.kt
+++ b/app/src/main/java/net/bible/android/view/activity/search/Search.kt
@@ -104,24 +104,14 @@ class Search : CustomTitlebarActivityBase(R.menu.search_actionbar_menu) {
         }
 
         title = getString(R.string.search_in, documentToSearch!!.abbreviation)
-        searchText.setOnEditorActionListener {v, actionId, event ->
+        searchText.setOnEditorActionListener {_, actionId, _ ->
             return@setOnEditorActionListener when (actionId) {
-                EditorInfo.IME_ACTION_SEARCH -> {
+                EditorInfo.IME_ACTION_SEARCH, EditorInfo.IME_ACTION_UNSPECIFIED -> {
                     onSearch(null)
                     true
                 }
                 else -> false
         }}
-
-        //searchText.setOnKeyListener(OnKeyListener { v, keyCode, event ->
-        //    // If the event is a key-down event on the "enter" button
-        //    if (event.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
-        //        // Perform action on key press
-        //        onSearch(null)
-        //        return@OnKeyListener true
-        //    }
-        //    false
-        //})
 
         // pre-load search string if passed in
         val extras = intent.extras


### PR DESCRIPTION
Fixes #572

EDIT: I'm noticing now that #572 is before #811 and it's fix (https://github.com/AndBible/and-bible/commit/9e20909232e65f54444ff3f2ac33fd1c216dc3ea)

This issue is most likely already fixed in commit mentioned above.