### PR TITLE
Highlight currently selected book in book chooser menu

### DIFF
--- a/app/src/main/java/net/bible/android/view/util/buttongrid/ButtonGrid.kt
+++ b/app/src/main/java/net/bible/android/view/util/buttongrid/ButtonGrid.kt
@@ -107,6 +107,7 @@ class ButtonGrid constructor(context: Context, attrs: AttributeSet? = null, defS
                         button.setTypeface(Typeface.DEFAULT_BOLD)
                         button.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize + 1.toFloat())
                         button.paintFlags = button.paintFlags or Paint.UNDERLINE_TEXT_FLAG
+                        button.isPressed = true
                     } else {
                         button.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize.toFloat())
                     }


### PR DESCRIPTION
**Describe the pull request content**
- One liner solution to set as pressed the button corresponding to highlighted in when choosing passage
- Previously selected book and chapter will be highlighted to ease jumping to  another passage and give a sense of  orientation so user experience will be  improved for passage selection while  navgating through  several passages in the Bible
- Fixes issue #97 

**Screenshots**
![book](https://user-images.githubusercontent.com/10614631/115797319-0c3ca180-a3aa-11eb-8aeb-08334b2f5672.png)
![chptr](https://user-images.githubusercontent.com/10614631/115797323-0e9efb80-a3aa-11eb-87da-6c9401c4bb6d.png)
![landscape](https://user-images.githubusercontent.com/10614631/115797333-12cb1900-a3aa-11eb-9b4c-7c617a68a12b.png)


