### PR TITLE
Instead of crashing if speak could not be toggled, show a toast instead.

### DIFF
--- a/app/src/main/java/net/bible/android/control/speak/SpeakControl.kt
+++ b/app/src/main/java/net/bible/android/control/speak/SpeakControl.kt
@@ -234,7 +234,8 @@ class SpeakControl @Inject constructor(
 
             } catch (e: Exception) {
                 Log.e(TAG, "Error getting chapters to speak", e)
-                throw AndRuntimeException("Error preparing Speech", e)
+                EventBus.getDefault().post(ToastEvent(R.string.speak_general_error))
+                return
             }
 
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -407,6 +407,7 @@
     <string name="speak_sleep_timer_title">Sleep timer</string>
 
     <string name="speak_no_books_available">No books available to speak</string>
+    <string name="speak_general_error">Speak could not be started for this book</string>
 
     <string name="repeat_passage">Repeat passage</string>
     <string name="set_repeat_passage_range">Set repeat passage range</string>


### PR DESCRIPTION
If you try to currently toggle speak while on a study pad, the app ends up crashing

I couldn't figure out how to disable the speak button for study pads, as it is categorized as a General Book, so instead of invoking a crash, perhaps it would be better to just show a Toast error instead. 