### PR TITLE
Apply the grid sorting preference to chapter & verse

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
@@ -313,7 +313,7 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
         private val REVELATION_COLOR = Color.rgb(0xFE, 0x33, 0xFF)
         private val OTHER_COLOR = ACTS_COLOR
 
-        private const val BOOK_GRID_FLOW_PREFS = "book_grid_ltr"
+        public const val BOOK_GRID_FLOW_PREFS = "book_grid_ltr"
         private const val TAG = "GridChoosePassageBook"
     }
 }

--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageChapter.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageChapter.kt
@@ -82,7 +82,7 @@ class GridChoosePassageChapter : CustomTitlebarActivityBase(), OnButtonGridActio
 
         val grid = ButtonGrid(this)
         grid.setOnButtonGridActionListener(this)
-
+        grid.isLeftToRightEnabled = CommonUtils.sharedPreferences.getBoolean(GridChoosePassageBook.BOOK_GRID_FLOW_PREFS, false)
         grid.addButtons(getBibleChaptersButtonInfo(mBibleBook))
         setContentView(grid)
     }

--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageVerse.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageVerse.kt
@@ -29,6 +29,7 @@ import net.bible.android.view.activity.base.CustomTitlebarActivityBase
 import net.bible.android.view.util.buttongrid.ButtonGrid
 import net.bible.android.view.util.buttongrid.ButtonInfo
 import net.bible.android.view.util.buttongrid.OnButtonGridActionListener
+import net.bible.service.common.CommonUtils
 
 import org.crosswire.jsword.passage.Verse
 import org.crosswire.jsword.versification.BibleBook
@@ -72,7 +73,7 @@ class GridChoosePassageVerse : CustomTitlebarActivityBase(), OnButtonGridActionL
 
         val grid = ButtonGrid(this)
         grid.setOnButtonGridActionListener(this)
-
+        grid.isLeftToRightEnabled = CommonUtils.sharedPreferences.getBoolean(GridChoosePassageBook.BOOK_GRID_FLOW_PREFS, false)
         grid.addButtons(getBibleVersesButtonInfo(mBibleBook, mBibleChapterNo))
         setContentView(grid)
     }


### PR DESCRIPTION
Apply the grid sorting preference for Bible books to the chapter and
verse selection grids.

Closes #1213 
Closes #1208