### PR TITLE
Show two color underline

### DIFF
--- a/app/bibleview-js/src/composables/bookmarks.js
+++ b/app/bibleview-js/src/composables/bookmarks.js
@@ -359,7 +359,7 @@ export function useBookmarks(documentId,
                 const label2 = (label == labels[0]) ? labels[1] : labels[0];
                 const color2 = new Color(label2.label.color).hsl().string();
                 const borderStyle = (labels.length === 2) ? 'solid' : 'double';
-                const borderWidth = (labels.length === 2) ? '2px' : '4px';
+                const borderWidth = (labels.length === 2) ? '0.1em' : '0.25em';
                 return `${baseDecoration}; border-bottom: ${borderWidth} ${borderStyle} ${color2};`;
             }
     }

--- a/app/bibleview-js/src/composables/bookmarks.js
+++ b/app/bibleview-js/src/composables/bookmarks.js
@@ -348,15 +348,20 @@ export function useBookmarks(documentId,
     }
 
     function underlineStyleForLabels(labels, underlineLabelCount) {
-        if(labels.length === 0) return "";
+            if(labels.length === 0) return "";
 
-        const label = labels.filter(l => l.label.isRealLabel)[0] || labels[0];
-        const color = new Color(label.label.color).hsl().string();
-        if(labels.length === 1 && underlineLabelCount.get(labels[0].id) === 1) {
-            return `text-decoration: underline; text-decoration-style: solid; text-decoration-color: ${color};`;
-        } else {
-            return `text-decoration: underline; text-decoration-style: double; text-decoration-color: ${color};`;
-        }
+            const label = labels.filter(l => l.label.isRealLabel)[0] || labels[0];
+            const color = new Color(label.label.color).hsl().string();
+            let baseDecoration = `text-decoration: underline; text-decoration-style: solid; text-decoration-color: ${color};`;
+            if(labels.length === 1 && underlineLabelCount.get(labels[0].id) === 1) {
+                return baseDecoration;
+            } else {
+                const label2 = (label == labels[0]) ? labels[1] : labels[0];
+                const color2 = new Color(label2.label.color).hsl().string();
+                const borderStyle = (labels.length === 2) ? 'solid' : 'double';
+                const borderWidth = (labels.length === 2) ? '2px' : '4px';
+                return `${baseDecoration}; border-bottom: ${borderWidth} ${borderStyle} ${color2};`;
+            }
     }
 
     function blendingStyleForLabels(bookmarkLabels, labelCount) {


### PR DESCRIPTION
This uses the border style to produce the second underline. The second color is determined by either the first or second label in the list.

If there are more than 2 labels the border is turned into a double border similar to before.

![image](https://user-images.githubusercontent.com/13920678/126866094-86a24490-633d-48f6-b8fc-72aebdd51ec4.png)

And three bookmark example....

![image](https://user-images.githubusercontent.com/13920678/126866075-e47f0986-c7c1-43ab-96ed-c28869f1947f.png)

