### PR TITLE
Fix book ending footers in KJV

### DIFF
--- a/app/bibleview-js/src/components/OSIS/Div.vue
+++ b/app/bibleview-js/src/components/OSIS/Div.vue
@@ -59,7 +59,7 @@ export default {
     return {verseInfo, shown, ...common};
   },
   computed : {
-    isParagraph: ({type, sID}) => ['x-p', 'paragraph'].includes(type) && sID,
+    isParagraph: ({type, sID}) => ['x-p', 'paragraph', 'colophon'].includes(type) && sID,
     isPreVerse,
     isCanonical: ({canonical}) => canonical !== "false",
   },


### PR DESCRIPTION
Closes #1133 

I don't know if this is the proper fix, but seems to be working.

Before (Colossians 4:18):
![Screenshot from 2021-08-01 14-49-51](https://user-images.githubusercontent.com/35117769/127784951-16a67922-d859-4138-836d-cac52eb162c1.png)

After:
![Screenshot from 2021-08-01 14-51-45](https://user-images.githubusercontent.com/35117769/127784992-3ee0d388-6f5f-4eaf-bf31-e4693fe5381b.png)

