### PR TITLE
Reverse the date order of the bookmark list so most recent are at the top.

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/bookmark/Bookmarks.kt
+++ b/app/src/main/java/net/bible/android/view/activity/bookmark/Bookmarks.kt
@@ -268,7 +268,8 @@ class Bookmarks : ListActivityBase(), ActionModeActivity {
     private fun changeBookmarkSortOrder() {
         bookmarkSortOrder = when (bookmarkSortOrder) {
             BookmarkSortOrder.BIBLE_ORDER -> BookmarkSortOrder.CREATED_AT_DESC
-            BookmarkSortOrder.CREATED_AT_DESC -> BookmarkSortOrder.BIBLE_ORDER
+            BookmarkSortOrder.CREATED_AT_DESC -> BookmarkSortOrder.CREATED_AT            
+            BookmarkSortOrder.CREATED_AT -> BookmarkSortOrder.BIBLE_ORDER
             else -> BookmarkSortOrder.CREATED_AT_DESC
         }
     }

--- a/app/src/main/java/net/bible/android/view/activity/bookmark/Bookmarks.kt
+++ b/app/src/main/java/net/bible/android/view/activity/bookmark/Bookmarks.kt
@@ -60,7 +60,8 @@ val BookmarkSortOrder.description get() =
     when(this) {
         BookmarkSortOrder.BIBLE_ORDER  -> CommonUtils.getResourceString(R.string.sort_by_bible_book)
         BookmarkSortOrder.LAST_UPDATED -> CommonUtils.getResourceString(R.string.sort_by_date)
-        BookmarkSortOrder.CREATED_AT -> CommonUtils.getResourceString(R.string.sort_by_date)
+        BookmarkSortOrder.CREATED_AT -> CommonUtils.getResourceString(R.string.sort_by_date) + "🠕"
+        BookmarkSortOrder.CREATED_AT_DESC -> CommonUtils.getResourceString(R.string.sort_by_date) + "🠗"
         BookmarkSortOrder.ORDER_NUMBER -> "order number"
     }
 
@@ -266,9 +267,9 @@ class Bookmarks : ListActivityBase(), ActionModeActivity {
 
     private fun changeBookmarkSortOrder() {
         bookmarkSortOrder = when (bookmarkSortOrder) {
-            BookmarkSortOrder.BIBLE_ORDER -> BookmarkSortOrder.CREATED_AT
-            BookmarkSortOrder.CREATED_AT -> BookmarkSortOrder.BIBLE_ORDER
-            else -> BookmarkSortOrder.CREATED_AT
+            BookmarkSortOrder.BIBLE_ORDER -> BookmarkSortOrder.CREATED_AT_DESC
+            BookmarkSortOrder.CREATED_AT_DESC -> BookmarkSortOrder.BIBLE_ORDER
+            else -> BookmarkSortOrder.CREATED_AT_DESC
         }
     }
 

--- a/app/src/main/java/net/bible/android/view/activity/bookmark/Bookmarks.kt
+++ b/app/src/main/java/net/bible/android/view/activity/bookmark/Bookmarks.kt
@@ -60,8 +60,8 @@ val BookmarkSortOrder.description get() =
     when(this) {
         BookmarkSortOrder.BIBLE_ORDER  -> CommonUtils.getResourceString(R.string.sort_by_bible_book)
         BookmarkSortOrder.LAST_UPDATED -> CommonUtils.getResourceString(R.string.sort_by_date)
-        BookmarkSortOrder.CREATED_AT -> CommonUtils.getResourceString(R.string.sort_by_date) + "🠕"
-        BookmarkSortOrder.CREATED_AT_DESC -> CommonUtils.getResourceString(R.string.sort_by_date) + "🠗"
+        BookmarkSortOrder.CREATED_AT -> CommonUtils.getResourceString(R.string.sort_by_date)
+        BookmarkSortOrder.CREATED_AT_DESC -> CommonUtils.getResourceString(R.string.sort_by_date)
         BookmarkSortOrder.ORDER_NUMBER -> "order number"
     }
 

--- a/db/src/main/java/net/bible/android/database/bookmarks/BookmarkEntities.kt
+++ b/db/src/main/java/net/bible/android/database/bookmarks/BookmarkEntities.kt
@@ -78,7 +78,7 @@ enum class BookmarkStyle(val backgroundColor: Int) {
 val defaultLabelColor = BookmarkStyle.BLUE_HIGHLIGHT.backgroundColor
 
 enum class BookmarkSortOrder {
-    BIBLE_ORDER, CREATED_AT, LAST_UPDATED, ORDER_NUMBER;
+    BIBLE_ORDER, CREATED_AT, CREATED_AT_DESC, LAST_UPDATED, ORDER_NUMBER;
 }
 
 interface VerseRangeUser {

--- a/db/src/main/java/net/bible/android/database/bookmarks/BookmarksDao.kt
+++ b/db/src/main/java/net/bible/android/database/bookmarks/BookmarksDao.kt
@@ -35,6 +35,7 @@ import java.util.*
 const val orderBy = """
 CASE WHEN :orderBy = 'BIBLE_ORDER' THEN Bookmark.kjvOrdinalStart END,
 CASE WHEN :orderBy = 'BIBLE_ORDER' THEN Bookmark.startOffset END,
+CASE WHEN :orderBy = 'CREATED_AT_DESC' THEN Bookmark.createdAt END DESC,
 CASE
     WHEN :orderBy = 'CREATED_AT' THEN Bookmark.createdAt
     WHEN :orderBy = 'LAST_UPDATED' THEN Bookmark.lastUpdatedOn
@@ -45,6 +46,7 @@ CASE WHEN :orderBy = 'BIBLE_ORDER' THEN Bookmark.kjvOrdinalStart END,
 CASE WHEN :orderBy = 'BIBLE_ORDER' THEN Bookmark.startOffset END,
 CASE
     WHEN :orderBy = 'CREATED_AT' THEN Bookmark.createdAt
+    WHEN :orderBy = 'CREATED_AT_DESC' THEN Bookmark.createdAt
     WHEN :orderBy = 'LAST_UPDATED' THEN Bookmark.lastUpdatedOn
     WHEN :orderBy = 'ORDER_NUMBER' THEN BookmarkToLabel.orderNumber
 END"""

--- a/db/src/main/java/net/bible/android/database/bookmarks/BookmarksDao.kt
+++ b/db/src/main/java/net/bible/android/database/bookmarks/BookmarksDao.kt
@@ -35,7 +35,7 @@ import java.util.*
 const val orderBy = """
 CASE WHEN :orderBy = 'BIBLE_ORDER' THEN Bookmark.kjvOrdinalStart END,
 CASE WHEN :orderBy = 'BIBLE_ORDER' THEN Bookmark.startOffset END,
-CASE WHEN :orderBy = 'CREATED_AT_DESC' THEN Bookmark.createdAt END DESC,
+CASE WHEN :orderBy = 'CREATED_AT_DESC' THEN Bookmark.createdAt DESC END,
 CASE
     WHEN :orderBy = 'CREATED_AT' THEN Bookmark.createdAt
     WHEN :orderBy = 'LAST_UPDATED' THEN Bookmark.lastUpdatedOn
@@ -46,7 +46,7 @@ CASE WHEN :orderBy = 'BIBLE_ORDER' THEN Bookmark.kjvOrdinalStart END,
 CASE WHEN :orderBy = 'BIBLE_ORDER' THEN Bookmark.startOffset END,
 CASE
     WHEN :orderBy = 'CREATED_AT' THEN Bookmark.createdAt
-    WHEN :orderBy = 'CREATED_AT_DESC' THEN Bookmark.createdAt
+    WHEN :orderBy = 'CREATED_AT_DESC' THEN Bookmark.createdAt DESC
     WHEN :orderBy = 'LAST_UPDATED' THEN Bookmark.lastUpdatedOn
     WHEN :orderBy = 'ORDER_NUMBER' THEN BookmarkToLabel.orderNumber
 END"""


### PR DESCRIPTION
My list is now realllly long. It takes 5 seconds or more to scroll to the bottom of the bookmarks. But almost always I am looking for bookmarks I just created or created recently... which were at the bottom. Now they are at the top.

I didn't know how to add an extra sort option - Biblical Order, Date Order, Date Order Desc.

There is no string i could use for the latter anyhow. So i have just reversed the current one.