### PR TITLE
Add two headings to make the backup form easier to read

### DIFF
--- a/app/src/main/res/layout/backup_view.xml
+++ b/app/src/main/res/layout/backup_view.xml
@@ -16,6 +16,12 @@
             android:id="@+id/backup_app"
             android:text="@string/backup_app"
             />
+        <TextView
+            android:id="@+id/textView2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/backup_button"
+            />
         <Button
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -27,6 +33,12 @@
             android:layout_height="wrap_content"
             android:id="@+id/backup_modules"
             android:text="@string/backup_modules"
+            />
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/restore_what"
             />
         <Button
             android:layout_width="match_parent"


### PR DESCRIPTION
I always find myself having to read each button to remember what one i want. I would like to make a lot more changes to this form to make it simpler but strings are very limited. This change provides some delineation between app (which i suspect is rarely used) and backup and restore