### PR TITLE
Show dictionary entries when dictionary is opened

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/navigation/ChooseDictionaryWord.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/ChooseDictionaryWord.kt
@@ -114,6 +114,7 @@ class ChooseDictionaryWord : ListActivityBase() {
             } finally {
                 withContext(Dispatchers.Main) {
                     binding.loadingIndicator.visibility = View.GONE
+                    showPossibleDictionaryKeys("")
                 }
             }
         }


### PR DESCRIPTION
I haven't liked how when opening a dictionary we get an almost completely empty form. It seems the time it takes to show all entries is very small. So after the list has been loaded into menu it immediately displays all entries.