### PR TITLE
Long-press in STUDYPAD mode to edit a label

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/bookmark/ManageLabelItemAdapter.kt
+++ b/app/src/main/java/net/bible/android/view/activity/bookmark/ManageLabelItemAdapter.kt
@@ -168,7 +168,7 @@ class ManageLabelItemAdapter(context: Context?,
                         manageLabels.editLabel(label)
                         true
                     }
-                } // else (mode == STUDYPAD)
+                } 
             }
         }
         return convertView?: bindings.root

--- a/app/src/main/java/net/bible/android/view/activity/bookmark/ManageLabelItemAdapter.kt
+++ b/app/src/main/java/net/bible/android/view/activity/bookmark/ManageLabelItemAdapter.kt
@@ -142,6 +142,7 @@ class ManageLabelItemAdapter(context: Context?,
                 } else {
                     labelIcon.setImageResource(R.drawable.ic_label_24dp)
                 }
+                labelIcon.setColorFilter(label.color)
 
                 // TODO: implement otherwise
                 bookmarkStyleAdapterHelper.styleView(labelName, label, context, false, false)
@@ -150,8 +151,24 @@ class ManageLabelItemAdapter(context: Context?,
                         Log.i(TAG, "Edit label clicked")
                         manageLabels.editLabel(label)
                     }
+                    // ensure that this listener is cleared when the mode is not STUDYPAD
+                    root.setOnLongClickListener(null)
                 }
-                labelIcon.setColorFilter(label.color)
+                // In STUDYPAD Mode:
+                //      * click selects the label and finishes the activity
+                //      * long-click navigates to the edit label activity
+                else {
+                    root.setOnClickListener {
+                        Log.i(TAG, "Select (studypad) label clicked")
+                        manageLabels.selectStudyPadLabel(label)
+                    }
+
+                    root.setOnLongClickListener {
+                        Log.i(TAG, "Edit label long-clicked (in STUDYPAD mode)")
+                        manageLabels.editLabel(label)
+                        true
+                    }
+                } // else (mode == STUDYPAD)
             }
         }
         return convertView?: bindings.root

--- a/app/src/main/java/net/bible/android/view/activity/bookmark/ManageLabels.kt
+++ b/app/src/main/java/net/bible/android/view/activity/bookmark/ManageLabels.kt
@@ -318,14 +318,6 @@ class ManageLabels : ListActivityBase() {
         }
     }
 
-    override fun onListItemClick(l: ListView, v: View, position: Int, id: Long) {
-        if(data.mode == Mode.STUDYPAD) {
-            val selected = shownLabels[position]
-            if(selected is BookmarkEntities.Label) saveAndExit(selected)
-        }
-        super.onListItemClick(l, v, position, id)
-    }
-
     fun ensureNotAutoAssignPrimaryLabel(label: BookmarkEntities.Label) {
         if (data.autoAssignPrimaryLabel == label.id || data.autoAssignPrimaryLabel == null) {
             data.autoAssignPrimaryLabel = data.autoAssignLabels.toList().firstOrNull()
@@ -443,6 +435,19 @@ class ManageLabels : ListActivityBase() {
                     listView.smoothScrollToPosition(shownLabels.indexOf(label))
                 }
             }
+        }
+    }
+
+    // This is called by the listener, which is created and configured by the list adapter
+    // It should only be called when the mode is STUDYPAD.  Nonetheless, I retained the mode check from the previous
+    // onListItemClick() method as an additional sanity check.
+    fun selectStudyPadLabel(selected: Any) {
+        if (data.mode == Mode.STUDYPAD) {
+            if (selected is BookmarkEntities.Label)
+                { saveAndExit(selected) }
+        }
+        else {
+            Log.e(TAG, "Call to selectStudyPadLabel() is unexpected when mode is not STUDYPAD.  mode=${data.mode}")
         }
     }
 

--- a/app/src/main/java/net/bible/android/view/activity/bookmark/ManageLabels.kt
+++ b/app/src/main/java/net/bible/android/view/activity/bookmark/ManageLabels.kt
@@ -443,8 +443,9 @@ class ManageLabels : ListActivityBase() {
     // onListItemClick() method as an additional sanity check.
     fun selectStudyPadLabel(selected: Any) {
         if (data.mode == Mode.STUDYPAD) {
-            if (selected is BookmarkEntities.Label)
-                { saveAndExit(selected) }
+            if (selected is BookmarkEntities.Label) { 
+                saveAndExit(selected) 
+            }
         }
         else {
             Log.e(TAG, "Call to selectStudyPadLabel() is unexpected when mode is not STUDYPAD.  mode=${data.mode}")


### PR DESCRIPTION
When displaying the list of labels in "STUDYPAD" mode, allow the user to
edit a label by long-press on the item.
