### PR TITLE
Moved the 'saved' indicator to the top.

### DIFF
--- a/app/bibleview-js/src/components/TextEditor.vue
+++ b/app/bibleview-js/src/components/TextEditor.vue
@@ -266,7 +266,7 @@ export default {
 .saved-notice {
   position: absolute;
   right: 5px;
-  bottom: $pell-button-height;
+  top:0px;
   padding-inline-end: 3pt;
   color: hsla(0, 0%, 0%, 0.2);
   .night & {


### PR DESCRIPTION
I find the '-saved-' indicator is often over the top of the text i am typing because it is at the same height as the last line of text. I have moved it to the first line of text which means it will rarely overlap what i have recently typed.