### PR TITLE
Decreased the length of the line separating the note from the verse

### DIFF
--- a/app/bibleview-js/src/common.scss
+++ b/app/bibleview-js/src/common.scss
@@ -128,10 +128,9 @@ $button-grey: #8e8e8e;
 
 .separator {
   border-width: 1pt 0 0 0;
-  border-style: dashed;
-
+  border-style: dotted;
   height: 1pt;
-  width: calc(100% - 10pt);
+  width: calc(33% - 10pt);
   margin: 10pt 5pt 5pt;
   border-color: rgba(0, 0, 0, 0.15);
   .night & {


### PR DESCRIPTION
I find it a little difficult to tell the difference between a note that is attached to a verse and a note that is attached to the study pad. The shorter line makes this distinction clear.

![image](https://user-images.githubusercontent.com/13920678/135755898-81e38c70-70ca-4eb5-92c0-383d596833bc.png)
