### PR TITLE
Override the English medium and long app name for debug builds

### DIFF
--- a/app/src/debug/res/values-en/strings.xml
+++ b/app/src/debug/res/values-en/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<resources>
+    <string name="app_name_medium">Bible Study App (And Bible) *Debug*</string>
+    <string name="app_name_long">Bible Study App, by And Bible Open Source Project *Debug*</string>
+</resources>


### PR DESCRIPTION
The medium and long app name strings are overridden by the "en"
translation, and thus for the 'debug' buildType they need to be
overridden in both the "en" and the default string values.
(see PR #1660)