### PR TITLE
Enabled swipe up and down on window buttons for maximise and minimise

### DIFF
--- a/app/src/main/java/net/bible/android/view/util/widget/WindowButtonWidget.kt
+++ b/app/src/main/java/net/bible/android/view/util/widget/WindowButtonWidget.kt
@@ -161,6 +161,13 @@ class WindowButtonWidget(
         super.setOnLongClickListener(l)
     }
 
+    override fun setOnTouchListener(l: OnTouchListener?) {
+        binding.apply {
+            windowButton.setOnTouchListener(l)
+        }
+        super.setOnTouchListener(l)
+    }
+
     var text: String
         get() = (if(isRestoreButton) binding.buttonText else binding.windowButton).text.toString()
 
@@ -221,5 +228,12 @@ class AddNewWindowButtonWidget(
             buttonText.setOnLongClickListener(l)
         }
         super.setOnLongClickListener(l)
+    }
+
+    override fun setOnTouchListener(l: OnTouchListener?) {
+        binding.apply {
+            buttonText.setOnTouchListener(l)
+        }
+        super.setOnTouchListener(l)
     }
 }


### PR DESCRIPTION
This addresses this request: https://github.com/AndBible/and-bible/issues/1070

I often want to minimise or maximise a window and I find both longpress and accessing the popup menu a little intrusive in my work flow. 

This change enables that functionality using swiping down and up which I have found really nice. I copied Tuomas' code from the workspace fling controls. It feels like my code should be in some more generic location that could be reused by other areas. But that is beyond me.

The only thing I don't like is that it is not immediately clear what has happened. Window animation would resolve that but that sounds tricky. Most people will not find this functionality unless it is promoted so it wont affect people.