### PR TITLE
Moved the 'saved' notice behind the text and changed it to an icon

### DIFF
--- a/app/bibleview-js/src/components/TextEditor.vue
+++ b/app/bibleview-js/src/components/TextEditor.vue
@@ -36,7 +36,7 @@
   </InputText>
   <div @click.stop class="edit-area pell">
     <div ref="editorElement"/>
-    <div class="saved-notice" v-if="!dirty">&dash;{{strings.saved}}&dash;</div>
+    <div class="saved-notice" v-if="!dirty"><FontAwesomeIcon icon="save"/></div>
   </div>
 </template>
 
@@ -219,6 +219,8 @@ export default {
   max-height: calc(var(--max-height) - #{$pell-button-height} - 2*#{$pell-content-padding});
   height: inherit;
   padding: 0 7px 5px 7px;
+  z-index:1;
+  position: relative;
 }
 .pell-button {
   color: inherit;
@@ -268,13 +270,13 @@ export default {
   right: 5px;
   bottom: $pell-button-height;
   padding-inline-end: 3pt;
-  color: hsla(0, 0%, 0%, 0.2);
+  color: hsla(113, 100%, 33%, 0.5);
   .night & {
-    color: hsla(0, 0%, 100%, 0.2);
+    color: hsla(113, 100%, 33%, 0.5);
   }
-  background: var(--background-color);
   opacity: 0.8;
-  font-size: 70%;
+  font-size: 16px;
+  z-index:0;
 }
 
 .pell-divider {

--- a/app/bibleview-js/src/composables/index.js
+++ b/app/bibleview-js/src/composables/index.js
@@ -39,7 +39,7 @@ import {
     faFileAlt, faFireAlt, faHandPointer,
     faHeadphones, faHeart, faHistory,
     faIndent, faInfoCircle, faOutdent, faPenSquare, faPlus,
-    faPlusCircle, faQuestionCircle, faShareAlt, faSort,
+    faPlusCircle, faQuestionCircle, faSave, faShareAlt, faSort,
     faTags, faTextWidth, faTimes, faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 
@@ -402,6 +402,7 @@ export function useFontAwesome() {
     library.add(faShareAlt);
     library.add(faQuestionCircle)
     library.add(faHandPointer)
+    library.add(faSave)
 }
 
 export function checkUnsupportedProps(props, attributeName, values = []) {


### PR DESCRIPTION
Changed the z-index to get the message behind the text and swapped the 'Saved' message with a saved icon.

![image](https://user-images.githubusercontent.com/13920678/137671096-577c09e1-d9f5-49a1-9a88-285c952d65f4.png)

![image](https://user-images.githubusercontent.com/13920678/137671056-70a72ab2-bd78-4ead-b398-60e340ee9774.png)
