### PR TITLE
Show the 'to' verse for the selected range

### DIFF
--- a/app/bibleview-js/src/components/modals/AmbiguousSelection.vue
+++ b/app/bibleview-js/src/components/modals/AmbiguousSelection.vue
@@ -55,7 +55,7 @@
     </div>
     <template #title>
       <template v-if="verseInfo">
-        {{ bibleBookName }} {{ verseInfo.chapter}}:{{verseInfo.verse}}
+        {{ bibleBookName }} {{ verseInfo.chapter}}:{{verseInfo.verse}}<template v-if="verseInfo.verseTo">-{{verseInfo.verseTo}}</template>
       </template>
       <template v-else>
         {{ strings.ambiguousSelection }}
@@ -169,6 +169,12 @@ export default {
       resetHighlights();
       for(let o of ordinalRange()) {
         highlightVerse(o);
+      }
+      if (endOrdinal.value == null || endOrdinal.value == startOrdinal.value){
+        verseInfo.value.verseTo = "";
+      } else {
+        //TODO: Check if selection goes into next chapter and display accordingly.
+        verseInfo.value.verseTo = verseInfo.value.verse + endOrdinal.value - startOrdinal.value;
       }
     }
 


### PR DESCRIPTION
When multiple verses are selected the range is shown (eg Hebrews 6:13-15) not just the first verse (Hebrews 6:13)

It doesn't handle cross chapter or book boundaries properly - just increments the to verse number. But I feel like this is still better than nothing.

![image](https://user-images.githubusercontent.com/13920678/138652017-f35be525-1b3f-4a48-974f-912c415946d1.png)
