### PR TITLE
Swipe action on window buttons to maximise and minimise windows

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/screen/BibleFrame.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/screen/BibleFrame.kt
@@ -118,7 +118,7 @@ class BibleFrame(
         val button =
             when {
                 isSingleWindow -> return
-                window.isLinksWindow -> createCloseButton(window)
+//                window.isLinksWindow -> createCloseButton(window)
                 else -> createWindowMenuButton(window)
             }
 
@@ -138,13 +138,13 @@ class BibleFrame(
                 if (isSingleWindow) Gravity.BOTTOM or Gravity.END else Gravity.TOP or Gravity.END))
     }
 
-    private fun createCloseButton(window: Window): WindowButtonWidget {
-        val text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) "☰" else "="
-        return createTextButton(text,
-            { v, motionEvent -> windowControl.closeWindow(window); true},
-            window
-        )
-    }
+//    private fun createCloseButton(window: Window): WindowButtonWidget {
+//        val text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) "☰" else "="
+//        return createTextButton(text,
+//            { v, motionEvent -> windowControl.closeWindow(window); true},
+//            window
+//        )
+//    }
 
     private fun createWindowMenuButton(window: Window): WindowButtonWidget {
         var gesturePerformed = GestureType.UNSET
@@ -191,7 +191,7 @@ class BibleFrame(
         val text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) "☰" else "="
         return createTextButton(text,
             { v, motionEvent -> gestureDetector.onTouchEvent(motionEvent)
-                                if (gesturePerformed === GestureType.SINGLE_TAP && (motionEvent.getAction() == MotionEvent.ACTION_UP)) {Log.d(TAG, "allViews.showPopupMenu(window, v) ")}
+                                if (gesturePerformed === GestureType.SINGLE_TAP && (motionEvent.getAction() == MotionEvent.ACTION_UP)) {allViews.showPopupMenu(window, v)}
                                 else if (gesturePerformed === GestureType.LONG_PRESS) {windowControl.minimiseWindow(window)}
                                 else if (gesturePerformed === GestureType.SWIPE_UP) {windowControl.maximiseWindow(window)}
                                 else if (gesturePerformed === GestureType.SWIPE_DOWN) {windowControl.minimiseWindow(window)}

--- a/app/src/main/java/net/bible/android/view/activity/page/screen/BibleFrame.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/screen/BibleFrame.kt
@@ -118,7 +118,6 @@ class BibleFrame(
         val button =
             when {
                 isSingleWindow -> return
-//                window.isLinksWindow -> createCloseButton(window)
                 else -> createWindowMenuButton(window)
             }
 
@@ -138,13 +137,6 @@ class BibleFrame(
                 if (isSingleWindow) Gravity.BOTTOM or Gravity.END else Gravity.TOP or Gravity.END))
     }
 
-//    private fun createCloseButton(window: Window): WindowButtonWidget {
-//        val text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) "☰" else "="
-//        return createTextButton(text,
-//            { v, motionEvent -> windowControl.closeWindow(window); true},
-//            window
-//        )
-//    }
 
     private fun createWindowMenuButton(window: Window): WindowButtonWidget {
         var gesturePerformed = GestureType.UNSET

--- a/app/src/main/java/net/bible/android/view/util/widget/WindowButtonWidget.kt
+++ b/app/src/main/java/net/bible/android/view/util/widget/WindowButtonWidget.kt
@@ -161,6 +161,13 @@ class WindowButtonWidget(
         super.setOnLongClickListener(l)
     }
 
+    override fun setOnTouchListener(l: OnTouchListener?) {
+        binding.apply {
+            windowButton.setOnTouchListener(l)
+        }
+        super.setOnTouchListener(l)
+    }
+
     var text: String
         get() = (if(isRestoreButton) binding.buttonText else binding.windowButton).text.toString()
 
@@ -221,5 +228,12 @@ class AddNewWindowButtonWidget(
             buttonText.setOnLongClickListener(l)
         }
         super.setOnLongClickListener(l)
+    }
+
+    override fun setOnTouchListener(l: OnTouchListener?) {
+        binding.apply {
+            buttonText.setOnTouchListener(l)
+        }
+        super.setOnTouchListener(l)
     }
 }


### PR DESCRIPTION
Window buttons (top right of the window) can now be swiped up and down to maximise and minimise the window. 

I use it quite often to quickly maximise a window rather than having to go through the popup menu. It feels much more natural now.

I use it less for minimising because the button bar at the bottom can do that as well. But it is still handy.