### PR TITLE
Increase default left/right margin to 3 (was 0)

### DIFF
--- a/db/src/main/java/net/bible/android/database/WorkspaceEntities.kt
+++ b/db/src/main/java/net/bible/android/database/WorkspaceEntities.kt
@@ -247,8 +247,8 @@ class WorkspaceEntities {
                     dayNoise = 0
                 ),
                 marginSize = MarginSize(
-                    marginLeft = 0,
-                    marginRight = 0,
+                    marginLeft = 3,
+                    marginRight = 3,
                     maxWidth = 170
                 ),
                 fontSize = 16,


### PR DESCRIPTION
This change should provide some usability benefits, by default:
 * provides a visual aesthetic while reading
 * always makes an empty region available to enter/leave full-screen
    mode without opening the quick-action menu
 * will keep the text out of the curved area of screens which extend to
    the edge of the device