### PR TITLE
Gave status bar a colour and made full screen mode immersive

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -28,6 +28,8 @@
     <color name="bar_window_button_background_colour_visible">#6A6A6A</color>
     <color name="bar_window_button_stroke_color">#686868</color>
 
+    <color name="status_bar">@color/black</color>
+
     <color name="window_button_text_colour">#32FFFFFF</color>
 
     <color name="navigation_bar">@color/black</color>

--- a/app/src/main/res/values-v27/barstyles.xml
+++ b/app/src/main/res/values-v27/barstyles.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
+    <style name="BaseAppTheme" parent="@style/Theme.AppCompat.DayNight.DarkActionBar">
+        <item name="actionMenuTextAppearance">@style/MyMenuTextAppearance</item>
+        <item name="actionButtonStyle">@style/MyActionButtonStyle</item>
+        <!-- Prevent sub menu items (e.g. Admin sub-menu) appearing as 'white on white' on Android 2.3 -->
+        <item name="actionBarWidgetTheme">@style/Theme.AppCompat.Light</item>
+        <item name="transportButtonColor">#ffffff</item>
+
+        <item name="windowButtonActiveStrokeColor">@color/bar_window_button_active_stroke_color
+        </item>
+        <item name="windowButtonStrokeColor">#00FFFFFF</item>
+        <item name="windowButtonBackgroundColor">#B78D8D8D</item>
+        <item name="windowButtonActiveBackgroundColor">#B7525252</item>
+
+        <item name="barWindowButtonActiveStrokeColor">@color/bar_window_button_active_stroke_color
+        </item>
+        <item name="barWindowButtonStrokeColor">@color/bar_window_button_stroke_color</item>
+        <item name="barWindowButtonBackgroundColor">@color/bar_window_button_background_colour
+        </item>
+        <item name="barWindowButtonActiveBackgroundColor">
+            @color/bar_window_button_background_colour_visible
+        </item>
+
+        <item name="bibleReferenceOverlayBackgroundColor">@color/bible_reference_overlay</item>
+
+        <item name="speakTransportBackground">#FFFFFF</item>
+        <item name="transportBarHeight">75dp</item>
+        <item name="windowButtonHeight">40dp</item>
+        <item name="toolbarTextColor">@color/white</item>
+
+        <item name="separatorBackgroundColor">#B1B1B1</item>
+        <item name="separatorActiveBackgroundColor">#FF6B6B6B</item>
+        <item name="separatorDragBackgroundColor">@color/yellow_500</item>
+        <item name="android:navigationBarColor" tools:targetApi="o_mr1">@color/navigation_bar</item>
+        <item name="android:textAlignment">gravity</item>
+        <item name="android:textDirection">locale</item>
+        <item name="android:statusBarColor" tools:targetApi="o_mr1">@color/status_bar</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/barstyles.xml
+++ b/app/src/main/res/values/barstyles.xml
@@ -41,6 +41,7 @@
 		<item name="android:navigationBarColor" tools:targetApi="o_mr1">@color/navigation_bar</item>
 		<item name="android:textAlignment">gravity</item>
 		<item name="android:textDirection">locale</item>
+		<item name="android:statusBarColor">@color/grey_800</item>
 	</style>
 
 

--- a/app/src/main/res/values/barstyles.xml
+++ b/app/src/main/res/values/barstyles.xml
@@ -41,7 +41,7 @@
 		<item name="android:navigationBarColor" tools:targetApi="o_mr1">@color/navigation_bar</item>
 		<item name="android:textAlignment">gravity</item>
 		<item name="android:textDirection">locale</item>
-		<item name="android:statusBarColor">@color/grey_800</item>
+		<item name="android:statusBarColor">@color/status_bar</item>
 		<item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
 	</style>
 

--- a/app/src/main/res/values/barstyles.xml
+++ b/app/src/main/res/values/barstyles.xml
@@ -42,7 +42,6 @@
 		<item name="android:textAlignment">gravity</item>
 		<item name="android:textDirection">locale</item>
 		<item name="android:statusBarColor">@color/status_bar</item>
-		<item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
 	</style>
 
 

--- a/app/src/main/res/values/barstyles.xml
+++ b/app/src/main/res/values/barstyles.xml
@@ -42,6 +42,7 @@
 		<item name="android:textAlignment">gravity</item>
 		<item name="android:textDirection">locale</item>
 		<item name="android:statusBarColor">@color/grey_800</item>
+		<item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
 	</style>
 
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -31,6 +31,8 @@
 	<!-- matches DKGRAY -->
 	<color name="actionbar_background_day">#ff444444</color>
 
+	<color name="status_bar">#ff444444</color>
+
 	<color name="actionbar_background">@color/actionbar_background_day</color>
 
 	<color name="actionbar_text_night">#919191</color>


### PR DESCRIPTION
Completely new to Android development. I have no idea if this has any unintended consequences. Fixes #1979

### Status bar is themed grey like the top bar
![Screenshot_20211213-144019_Bible Study _Debug_](https://user-images.githubusercontent.com/56124831/145787595-bce1da67-3384-4abc-a732-2669e3e5dab8.png)

### Full screen is immersive, no black bar on top
![Screenshot_20211213-150655_Bible Study _Debug_](https://user-images.githubusercontent.com/56124831/145787738-fc4fad91-8dbe-482e-accc-dd3a4e8d0192.png)

