### PR TITLE
Remember the last document type selected in the Documents list window

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/base/DocumentSelectionBase.kt
+++ b/app/src/main/java/net/bible/android/view/activity/base/DocumentSelectionBase.kt
@@ -157,7 +157,6 @@ abstract class DocumentSelectionBase(optionsMenuId: Int, private val actionModeM
 
         //prepare the documentType spinner
         setInitialDocumentType()
-
         binding.apply {
             okButtonPanel.visibility = if (showOkButton) View.VISIBLE else View.GONE
 
@@ -165,6 +164,7 @@ abstract class DocumentSelectionBase(optionsMenuId: Int, private val actionModeM
             documentTypeSpinner.onItemSelectedListener = object : OnItemSelectedListener {
                 override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                     selectedDocumentFilterNo = position
+                    CommonUtils.settings.setInt("selected_document_filter_no", position)
                     filterDocuments()
                 }
 
@@ -589,7 +589,7 @@ abstract class DocumentSelectionBase(optionsMenuId: Int, private val actionModeM
     /** allow selection of initial doc type
      */
     protected open fun setInitialDocumentType() {
-        selectedDocumentFilterNo = if(intent?.getBooleanExtra("addons", false) == true) 6 else 0
+        selectedDocumentFilterNo = if(intent?.getBooleanExtra("addons", false) == true) 6 else CommonUtils.settings.getInt("selected_document_filter_no", 0)
     }
 
     fun setShowOkButtonBar(visible: Boolean) {

--- a/app/src/main/java/net/bible/android/view/activity/navigation/ChooseDocument.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/ChooseDocument.kt
@@ -61,7 +61,7 @@ class ChooseDocument : DocumentSelectionBase(R.menu.choose_document_menu, R.menu
         selectedDocumentFilterNo = when(intent.extras?.getString("type")) {
             "BIBLE" -> 1
             "COMMENTARY" -> 2
-            else -> 0
+            else -> CommonUtils.settings.getInt("selected_document_filter_no", 0)
         }
     }
 


### PR DESCRIPTION
It has frustrated me when i go to the document selector that it always shows me every document. Now it remembers the previous selection.