### PR TITLE
fix: reading plan menu

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/base/CustomTitlebarActivityBase.kt
+++ b/app/src/main/java/net/bible/android/view/activity/base/CustomTitlebarActivityBase.kt
@@ -50,6 +50,19 @@ abstract class CustomTitlebarActivityBase(private val optionsMenuId: Int = NO_OP
         return super.onCreateOptionsMenu(menu)
     }
 
+    /**
+     * Allow some menu items to be hidden or otherwise altered
+     */
+    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+        super.onPrepareOptionsMenu(menu)
+
+        actionBarManager.prepareOptionsMenu(this, menu, supportActionBar)
+
+        // must return true for menu to be displayed
+        return true
+    }
+
+
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
 

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
@@ -57,7 +57,9 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
 
     private lateinit var binding: ReadingPlanOneDayBinding
 
-    private var dayLoaded: Int = 0
+    var dayLoaded: Int = 0
+        private set
+
     private var planCodeLoaded: String? = null
 
     private lateinit var readingsDto: OneDaysReadingsDto

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/actionbar/ReadingPlanTitle.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/actionbar/ReadingPlanTitle.kt
@@ -175,7 +175,8 @@ constructor(private val readingPlanControl: ReadingPlanControl) {
 
     private val pageTitleParts: Array<String>
         get() {
-            val planDayDesc = readingPlanControl.currentDayDescription
+            // get the current day loaded for the page title, not the current plan day
+            val planDayDesc = readingPlanControl.getDaysReading((activity as DailyReading).dayLoaded).dayDesc
             return getTwoTitleParts(planDayDesc, true)
         }
 


### PR DESCRIPTION
**Describe the pull request content**
Closes #2064 #2063 

Also fixes an issue where the currently selected reading plan day was not displayed correctly in the toolbar. 

**Screenshots**
If applicable, add screenshots to help explain your pull request.
