### PR TITLE
Show long names for books of the bible

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
@@ -69,7 +69,6 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
     // this is used for preview
     private val bibleBookButtonInfo: List<ButtonInfo>
         get() {
-            val isShortBookNamesAvailable = isShortBookNames
             val currentBibleBook = KeyUtil.getVerse(activeWindowPageManagerProvider.activeWindowPageManager.currentBible.key).book
 
             val bibleBookList = navigationControl.getBibleBooks(isCurrentlyShowingScripture)
@@ -78,7 +77,7 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
                 val buttonInfo = ButtonInfo()
                 try {
                     buttonInfo.id = book.ordinal
-                    buttonInfo.name = getShortBookName(book, isShortBookNamesAvailable)
+                    buttonInfo.name = versification.getLongName(book)
                     buttonInfo.description = versification.getLongName(book)
                     val BookColorAndGroup = getBookColorAndGroup(book.ordinal)
                     buttonInfo.textColor = BookColorAndGroup.Color
@@ -92,17 +91,6 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
                 keys.add(buttonInfo)
             }
             return keys
-        }
-
-    // should never get here
-    private val isShortBookNames: Boolean
-        get() {
-            return try {
-                versification.getShortName(BibleBook.GEN) != versification.getLongName(BibleBook.GEN)
-            } catch (nsve: Exception) {
-                Log.e(TAG, "No such bible book no: 1", nsve)
-                false
-            }
         }
 
     private val versification: Versification

--- a/app/src/main/java/net/bible/android/view/util/buttongrid/LayoutDesigner.kt
+++ b/app/src/main/java/net/bible/android/view/util/buttongrid/LayoutDesigner.kt
@@ -44,10 +44,10 @@ class LayoutDesigner(private val view: View) {
         private val BIBLE_BOOK_LAYOUT_LAND = RowColLayout()
 
         init {
-            BIBLE_BOOK_LAYOUT.rows = 11
-            BIBLE_BOOK_LAYOUT.cols = 6
-            BIBLE_BOOK_LAYOUT_LAND.rows = 6
-            BIBLE_BOOK_LAYOUT_LAND.cols = 11
+            BIBLE_BOOK_LAYOUT.rows = 66
+            BIBLE_BOOK_LAYOUT.cols = 1
+            BIBLE_BOOK_LAYOUT_LAND.rows = 1
+            BIBLE_BOOK_LAYOUT_LAND.cols = 66
         }
     }
 

--- a/app/src/main/res/layout/buttongrid_button_preview.xml
+++ b/app/src/main/res/layout/buttongrid_button_preview.xml
@@ -18,11 +18,10 @@
 --> 
  
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content" 
-    android:layout_height="40dip"
+    android:layout_width="fill_parent"
+    android:layout_height="80dip"
     android:textSize="18sp"
     android:textColor="@color/buttongrid_button_feedback_text"
-    android:minWidth="32dip"
     android:gravity="center"
     android:background="@drawable/buttongrid_button_feedback_background"
     />


### PR DESCRIPTION
**Describe the pull request content**
Use full book names instead of abbreviations, e.g., Genesis instead of Gen.

What are the benefits of this new code addition? It's much easier to find a book using the full name instead of the abbreviation.

Possible negative side effects? I'm not sure if there are any. This is more cosmetic than anything.

Closes: https://github.com/AndBible/and-bible/issues/142