### PR TITLE
CI: Add app version suffix for -alpha and -beta builds

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: '11' # later than 1.8 not working with roboelectric as of 2020-06-15
+        java-version: '11'
 
     - name: Set up Node.js environment
       uses: actions/setup-node@v2
@@ -56,6 +56,16 @@ jobs:
         openssl enc -in ./testmods.zip.enc -out ./testmods.zip -d -aes-256-cbc -pbkdf2 -pass 'pass:${{ secrets.TEST_MODULE_ENCRYPTION_KEY }}'
         mkdir -p $HOME/.sword
         unzip -o -d $HOME/.sword ./testmods.zip
+
+    - name: Check/set alpha version suffix
+      if: contains(github.ref, 'refs/tags/alpha-')
+      run: |
+        sed -i 's/\(android:versionName="[0-9]*.[0-9]*.[0-9]*\)/\1-alpha/' ./app/src/main/AndroidManifest.xml
+
+    - name: Check/set beta version suffix
+      if: contains(github.ref, 'refs/tags/beta-')
+      run: |
+        sed -i 's/\(android:versionName="[0-9]*.[0-9]*.[0-9]*\)/\1-beta/' ./app/src/main/AndroidManifest.xml
 
     - name: Build with Gradle
       run: ./gradlew --console plain assembleGithubRelease


### PR DESCRIPTION
I think this would be nice... @tuomas2 

When tagging for alpha- or beta- builds, this will add -alpha or -beta to the version name before building apk

Side note: I tested `sed` command to work but I have not tested in GitHub CI