### PR TITLE
Fix "Set as current day" in reading plan

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
@@ -336,9 +336,17 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
             try {
                 Dialogs.instance.showMsg(R.string.msg_set_current_day_reading_plan, true)
                 {
+                    // Change start date so that the current plan day is today
+                    val planStartDate = Calendar.getInstance()
+                    planStartDate.add(Calendar.DATE, - (dayLoaded - 1))
+                    readingPlanControl.setStartDate(readingsDto.readingPlanInfo, planStartDate.time)
+
                     // set previous day as finish, so that today's reading status will not be changed
                     readingPlanControl.done(readingsDto.readingPlanInfo, dayLoaded - 1, true)
+
                     updateTicksAndDone()
+
+                    loadDailyReading(planCodeLoaded, dayLoaded)
                 }
 
             } catch (e: Exception) {

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
@@ -344,8 +344,6 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
                     // set previous day as finish, so that today's reading status will not be changed
                     readingPlanControl.done(readingsDto.readingPlanInfo, dayLoaded - 1, true)
 
-                    updateTicksAndDone()
-
                     loadDailyReading(planCodeLoaded, dayLoaded)
                 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
I believe "Set as current day" should also set the start day of a reading plan such that the current plan day is today. This PR fixes the issue.

I have also removed MaxPermSize from `gradle.properties` since it is deprecated and it produces error in latest JDK.