### PR TITLE
Close the InputStream after loading repositories.txt

### DIFF
--- a/app/src/main/java/net/bible/android/BibleApplication.kt
+++ b/app/src/main/java/net/bible/android/BibleApplication.kt
@@ -98,7 +98,9 @@ open class BibleApplication : Application() {
         ABEventBus.getDefault().register(this)
         InstallManager.installSiteMap(
             PropertyMap().apply {
-                load(resources.openRawResource(R.raw.repositories))
+                resources.openRawResource(R.raw.repositories).use {
+                    load(it)
+                }
             })
         BookType.addSupportedBookType(myBibleBible)
         BookType.addSupportedBookType(myBibleCommentary)


### PR DESCRIPTION
The load() method leaves the stream open.  It will probably be closed, eventually, by the garbage collector but this ensures it is closed immediately.