### PR TITLE
Changed how <i> tags in text from MyBible modules are handled

### DIFF
--- a/app/bibleview-js/src/components/MyBible/I.vue
+++ b/app/bibleview-js/src/components/MyBible/I.vue
@@ -1,0 +1,41 @@
+<!--
+  - Copyright (c) 2022 Martin Denham, Tuomas Airaksinen and the And Bible contributors.
+  -
+  - This file is part of And Bible (http://github.com/AndBible/and-bible).
+  -
+  - And Bible is free software: you can redistribute it and/or modify it under the
+  - terms of the GNU General Public License as published by the Free Software Foundation,
+  - either version 3 of the License, or (at your option) any later version.
+  -
+  - And Bible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  - without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  - See the GNU General Public License for more details.
+  -
+  - You should have received a copy of the GNU General Public License along with And Bible.
+  - If not, see http://www.gnu.org/licenses/.
+  -->
+
+<template>
+  <span v-if="show" :class="{nonCanonical: config.makeNonCanonicalItalic && isNonCanonical}"><slot/></span>
+</template>
+
+<script>
+import {useCommon} from "@/composables";
+import {computed} from "@vue/reactivity";
+
+export default {
+  name: "I",
+  setup() {
+    const {config, ...common} = useCommon();
+    const isNonCanonical = computed(() => true);
+    const show = computed(() => (!isNonCanonical.value) || (isNonCanonical.value && config.showNonCanonical));
+    return {show, isNonCanonical, config, ...common};
+  },
+}
+</script>
+
+<style scoped>
+.nonCanonical {
+  font-style: italic;
+}
+</style>

--- a/app/bibleview-js/src/components/documents/OsisSegment.vue
+++ b/app/bibleview-js/src/components/documents/OsisSegment.vue
@@ -51,6 +51,7 @@ import AndBibleLink from "@/components/OSIS/AndBibleLink";
 import Pb from "@/components/MyBible/Pb";
 import NoOp from "@/components/OSIS/NoOp";
 import H3 from "@/components/MyBible/H3";
+import I from "@/components/MyBible/I";
 import S from "@/components/MyBible/S";
 
 const teiComponents = {
@@ -63,7 +64,7 @@ const andBibleComponents = {
 }
 
 const myBibleComponents = {
-  S, M: NoOp, I:Note, J:Q, N: Note, Pb, F: NoOp, H: Title, E: Hi, H3,
+  S, M: NoOp, I, J:Q, N: Note, Pb, F: NoOp, H: Title, E: Hi, H3,
 }
 
 const osisComponents = {


### PR DESCRIPTION
Display an `<i>` element from the text of a MyBible module like an
OSIS `<transChange type="added">` element.

This fixes the issue described by timbze in https://github.com/AndBible/and-bible/issues/2133#issuecomment-1098249508
