### PR TITLE
fix: declare TTS service as mediaPlayback

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -226,7 +226,9 @@
             </intent-filter>
         </activity>
 
-        <service android:name="net.bible.service.device.speak.TextToSpeechNotificationManager$ForegroundService" />
+        <service
+            android:name="net.bible.service.device.speak.TextToSpeechNotificationManager$ForegroundService"
+            android:foregroundServiceType="mediaPlayback" />
 
         <receiver
             android:name="net.bible.service.device.speak.TextToSpeechNotificationManager$NotificationReceiver"


### PR DESCRIPTION
Might help with #2145. 

**Describe the pull request content**
Declares the TTS service as media playback. This might prevent [some phone manufacturer's custom battery saving measures](https://dontkillmyapp.com) from killing the service prematurely. 

**Screenshots**
If applicable, add screenshots to help explain your pull request.
