### PR TITLE
Workaround duplicate classes from transitive dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -342,9 +342,15 @@ dependencies {
 
     // Espresso dependencies
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
-    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.4.0")
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.4.0") {
+        // https://github.com/android/android-test/issues/861#issuecomment-1067448610
+        exclude(group="org.checkerframework", module="checker")
+        }
     androidTestImplementation("androidx.test.espresso:espresso-intents:3.4.0")
-    androidTestImplementation("androidx.test.espresso:espresso-accessibility:3.4.0")
+    androidTestImplementation("androidx.test.espresso:espresso-accessibility:3.4.0") {
+        // https://github.com/android/android-test/issues/861#issuecomment-872582819
+        exclude(group="org.checkerframework", module="checker")
+        }
     androidTestImplementation("androidx.test.espresso:espresso-web:3.4.0")
     androidTestImplementation("androidx.test.espresso.idling:idling-concurrent:3.4.0")
 


### PR DESCRIPTION
Reference: https://github.com/android/android-test/issues/861

The transitive dependencies of espresso-accessibility and
espresso-contrib include versions of both "checker", and "checker-qual"
which contains a portion of "checker".  This results in duplicate
classes which cause the build of "androidTest" variants to fail.

This commit applies the workaround, described in the referenced github
issue, of excluding "checker" from the transitive dependencies.
