### PR TITLE
Replace ActivityTestRule with ActivityScenario.launch()

### DIFF
--- a/app/src/androidTest/java/net/bible/android/MainBibleActivityTests.kt
+++ b/app/src/androidTest/java/net/bible/android/MainBibleActivityTests.kt
@@ -18,27 +18,26 @@
 
 package net.bible.android
 
+import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.junit.runner.RunWith
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.rule.ActivityTestRule
 import net.bible.android.activity.R
 
 import net.bible.android.view.activity.page.MainBibleActivity
-import org.junit.Rule
 import org.junit.Test
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class MainBibleActivityTests {
-    @get:Rule var activityRule: ActivityTestRule<MainBibleActivity>
-        = ActivityTestRule(MainBibleActivity::class.java)
 
     @Test
     fun testMainActivity() {
-        //mainBibleActivity.windowControl.activeWindowPageManager.currentPage.key =
-        onView(withId(R.id.speakButton))
+        launch(MainBibleActivity::class.java).use {
+            //mainBibleActivity.windowControl.activeWindowPageManager.currentPage.key =
+            onView(withId(R.id.speakButton))
+        }
     }
 }


### PR DESCRIPTION
ActivityTestRule is deprecated, superseded by ActivityScenario.launch()