### PR TITLE
Adjusted Verse selector button color so that it is easy to see what verse is currently selected 

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
@@ -317,7 +317,7 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
         private const val TAG = "GridChoosePassageBook"
 
         fun getBookColorAndGroup(bookNo: Int):  ExtraBookInfo {
-            // colour and grouping taken from http://en.wikipedia.org/wiki/Books_of_the_Bible
+            // Colour and Grouping taken from http://en.wikipedia.org/wiki/Books_of_the_Bible
             return when {
                 bookNo <= BibleBook.DEUT.ordinal -> // Pentateuch - books of Moses
                     ExtraBookInfo(PENTATEUCH_COLOR, "PENTATEUCH", "PENTATEUCH")

--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
@@ -81,11 +81,16 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
                     buttonInfo.name = getShortBookName(book, isShortBookNamesAvailable)
                     buttonInfo.description = versification.getLongName(book)
                     val BookColorAndGroup = getBookColorAndGroup(book.ordinal)
-                    buttonInfo.textColor = BookColorAndGroup.Color
                     buttonInfo.GroupA = BookColorAndGroup.GroupA
                     buttonInfo.GroupB = BookColorAndGroup.GroupB
-                    buttonInfo.tintColor = if (book.ordinal < BibleBook.MATT.ordinal) Color.DKGRAY else NEW_TESTAMENT_TINT
-                    buttonInfo.highlight = book == currentBibleBook
+                    if (book == currentBibleBook) {
+                        buttonInfo.tintColor = BookColorAndGroup.Color
+                        buttonInfo.textColor = Color.DKGRAY
+                    } else {
+                        buttonInfo.textColor = BookColorAndGroup.Color
+                        buttonInfo.tintColor = if (book.ordinal < BibleBook.MATT.ordinal) Color.DKGRAY else NEW_TESTAMENT_TINT
+                    }
+//                    buttonInfo.highlight = book == currentBibleBook  // Highlighting the button adds an underline which is no longer need and looks a little ugly.
                 } catch (nsve: NoSuchVerseException) {
                     buttonInfo.name = "ERR"
                 }
@@ -286,32 +291,7 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
         return shortenedName.toString()
     }
 
-    private fun getBookColorAndGroup(bookNo: Int):  ExtraBookInfo {
-        // colour and grouping taken from http://en.wikipedia.org/wiki/Books_of_the_Bible
-        return when {
-            bookNo <= BibleBook.DEUT.ordinal -> // Pentateuch - books of Moses
-                ExtraBookInfo(PENTATEUCH_COLOR, "PENTATEUCH", "PENTATEUCH")
-            bookNo <= BibleBook.ESTH.ordinal -> // History
-                ExtraBookInfo(HISTORY_COLOR, "HISTORY", "HISTORY")
-            bookNo <= BibleBook.SONG.ordinal -> // Wisdom
-                ExtraBookInfo(WISDOM_COLOR, "WISDOM", "WISDOM")
-            bookNo <= BibleBook.DAN.ordinal -> // Major prophets
-                ExtraBookInfo(MAJOR_PROPHETS_COLOR, "MAJOR", "MAJOR")
-            bookNo <= BibleBook.MAL.ordinal -> // Minor prophets
-                ExtraBookInfo(MINOR_PROPHETS_COLOR, "MINOR", "MINOR")
-            bookNo <= BibleBook.JOHN.ordinal -> // Gospels
-                ExtraBookInfo(GOSPEL_COLOR, "GOSPEL", "GOSPEL+ACTS")
-            bookNo <= BibleBook.ACTS.ordinal -> // Acts
-                ExtraBookInfo(ACTS_COLOR, "ACTS", "GOSPEL+ACTS")
-            bookNo <= BibleBook.PHLM.ordinal -> // Pauline epistles
-                ExtraBookInfo(PAULINE_COLOR, "PAULINE", "PAULINE")
-            bookNo <= BibleBook.JUDE.ordinal -> // General epistles
-                ExtraBookInfo(GENERAL_EPISTLES_COLOR, "GENERAL", "GENERAL+REVELATION")
-            bookNo <= BibleBook.REV.ordinal -> // Revelation
-                ExtraBookInfo(REVELATION_COLOR, "REVELATION", "GENERAL+REVELATION")
-            else -> ExtraBookInfo(OTHER_COLOR,"", "")
-        }
-    }
+
     companion object {
 
         const val BOOK_NO = "BOOK_NO"
@@ -335,5 +315,32 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
         public const val BOOK_GRID_FLOW_PREFS = "book_grid_ltr"
         public const val BOOK_GRID_FLOW_PREFS_GROUP_BY_CATEGORY = "book_grid_group_by_category"
         private const val TAG = "GridChoosePassageBook"
+
+        fun getBookColorAndGroup(bookNo: Int):  ExtraBookInfo {
+            // colour and grouping taken from http://en.wikipedia.org/wiki/Books_of_the_Bible
+            return when {
+                bookNo <= BibleBook.DEUT.ordinal -> // Pentateuch - books of Moses
+                    ExtraBookInfo(PENTATEUCH_COLOR, "PENTATEUCH", "PENTATEUCH")
+                bookNo <= BibleBook.ESTH.ordinal -> // History
+                    ExtraBookInfo(HISTORY_COLOR, "HISTORY", "HISTORY")
+                bookNo <= BibleBook.SONG.ordinal -> // Wisdom
+                    ExtraBookInfo(WISDOM_COLOR, "WISDOM", "WISDOM")
+                bookNo <= BibleBook.DAN.ordinal -> // Major prophets
+                    ExtraBookInfo(MAJOR_PROPHETS_COLOR, "MAJOR", "MAJOR")
+                bookNo <= BibleBook.MAL.ordinal -> // Minor prophets
+                    ExtraBookInfo(MINOR_PROPHETS_COLOR, "MINOR", "MINOR")
+                bookNo <= BibleBook.JOHN.ordinal -> // Gospels
+                    ExtraBookInfo(GOSPEL_COLOR, "GOSPEL", "GOSPEL+ACTS")
+                bookNo <= BibleBook.ACTS.ordinal -> // Acts
+                    ExtraBookInfo(ACTS_COLOR, "ACTS", "GOSPEL+ACTS")
+                bookNo <= BibleBook.PHLM.ordinal -> // Pauline epistles
+                    ExtraBookInfo(PAULINE_COLOR, "PAULINE", "PAULINE")
+                bookNo <= BibleBook.JUDE.ordinal -> // General epistles
+                    ExtraBookInfo(GENERAL_EPISTLES_COLOR, "GENERAL", "GENERAL+REVELATION")
+                bookNo <= BibleBook.REV.ordinal -> // Revelation
+                    ExtraBookInfo(REVELATION_COLOR, "REVELATION", "GENERAL+REVELATION")
+                else -> ExtraBookInfo(OTHER_COLOR,"", "")
+            }
+        }
     }
 }

--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageChapter.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageChapter.kt
@@ -106,9 +106,8 @@ class GridChoosePassageChapter : CustomTitlebarActivityBase(), OnButtonGridActio
         } catch (nsve: Exception) {
             -1
         }
-        val currentVerse = KeyUtil.getVerse(activeWindowPageManagerProvider.activeWindowPageManager.currentBible.key)
-        val currentBibleBook = currentVerse.book
-        val currentBibleChapter = currentVerse.chapter
+        val currentVerse = activeWindowPageManagerProvider.activeWindowPageManager.currentPage.singleKey as Verse
+        val bookColorAndGroup = GridChoosePassageBook.getBookColorAndGroup(book.ordinal)
 
         val keys = ArrayList<ButtonInfo>()
         for (i in 1..chapters) {
@@ -117,9 +116,9 @@ class GridChoosePassageChapter : CustomTitlebarActivityBase(), OnButtonGridActio
             buttonInfo.id = i
             buttonInfo.name = i.toString()
             buttonInfo.description = i.toString()
-            if (currentBibleBook == book && i == currentBibleChapter) {
-                buttonInfo.textColor = Color.YELLOW
-                buttonInfo.highlight = true
+            if (currentVerse.book == book && i == currentVerse.chapter) {
+                buttonInfo.tintColor = bookColorAndGroup.Color
+                buttonInfo.textColor = Color.DKGRAY
             }
             keys.add(buttonInfo)
         }

--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageVerse.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageVerse.kt
@@ -20,6 +20,7 @@ package net.bible.android.view.activity.navigation
 
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
@@ -31,6 +32,7 @@ import net.bible.android.view.util.buttongrid.ButtonGrid
 import net.bible.android.view.util.buttongrid.ButtonInfo
 import net.bible.android.view.util.buttongrid.OnButtonGridActionListener
 import net.bible.service.common.CommonUtils
+import org.crosswire.jsword.passage.KeyUtil
 
 import org.crosswire.jsword.passage.Verse
 import org.crosswire.jsword.versification.BibleBook
@@ -99,12 +101,20 @@ class GridChoosePassageVerse : CustomTitlebarActivityBase(), OnButtonGridActionL
             -1
         }
 
+        val bookColorAndGroup = GridChoosePassageBook.getBookColorAndGroup(book.ordinal)
+        val currentVerse = activeWindowPageManagerProvider.activeWindowPageManager.currentPage.singleKey as Verse
+
         val keys = ArrayList<ButtonInfo>()
         for (i in 1..verses) {
             val buttonInfo = ButtonInfo()
             // this is used for preview
             buttonInfo.id = i
             buttonInfo.name = Integer.toString(i)
+            if (i == currentVerse.verse && chapterNo == currentVerse.chapter && book == currentVerse.book) {
+                buttonInfo.tintColor = bookColorAndGroup.Color
+                buttonInfo.textColor = Color.DKGRAY
+            }
+
             keys.add(buttonInfo)
         }
         return keys


### PR DESCRIPTION
I have always found it hard to see which book or chapter was highlighted indicating the current verse.  This change makes it very easy. I have also enabled the highlight for the current verse - I sometimes want to know that. The button color uses the default color for the book - so it changes depending on which book is current.

![image](https://user-images.githubusercontent.com/13920678/173186093-31d200f1-465a-4bc1-b661-6d78e9b393b4.png)

![image](https://user-images.githubusercontent.com/13920678/173186000-67c5e905-b1c0-4a1c-8e8f-5fd22b655442.png)

![image](https://user-images.githubusercontent.com/13920678/173186016-cde7df18-2295-411b-8831-68e860d419f7.png)

![image](https://user-images.githubusercontent.com/13920678/173186027-b36a1b36-f0f0-4c3c-8d8c-1896c9d87798.png)
