### PR TITLE
Disable the ability to insert a new line when adding a new label

### DIFF
--- a/app/src/main/res/layout/bookmark_label_edit.xml
+++ b/app/src/main/res/layout/bookmark_label_edit.xml
@@ -27,6 +27,7 @@
 			android:layout_width="0dp"
 			android:layout_height="wrap_content"
 			android:hint="@string/label_name_prompt"
+			android:inputType="textPersonName"
 			android:textAppearance="?android:attr/textAppearanceMedium"
 			app:layout_constraintEnd_toEndOf="parent"
 			app:layout_constraintStart_toEndOf="@id/titleIcon"


### PR DESCRIPTION
Pushing enter when entering the name of a new label would create a new line. I don't think there is ever an instance when we want a new line in a label name.

The option I used automatically capitalises each word. This is the same option used when entering a label name to search for.