### PR TITLE
Improved backup and restore UI

### DIFF
--- a/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
+++ b/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
@@ -29,6 +29,7 @@ import android.util.Log
 import android.view.View
 import android.widget.Button
 import androidx.core.content.FileProvider
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -522,54 +523,41 @@ object BackupControl {
 
 class BackupActivity: ActivityBase() {
     lateinit var binding: BackupViewBinding
+    val backupScope = CoroutineScope(Dispatchers.Default)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         buildActivityComponent().inject(this)
         binding = BackupViewBinding.inflate(layoutInflater)
         setContentView(binding.root)
         binding.apply {
-//            restoreModules.text = "${getString(R.string.install_zip)} / ${getString(R.string.restore_modules)}"
-
             toggleBackupApplication.isChecked = CommonUtils.settings.getBoolean("backup_application", false)
             toggleBackupDatabase.isChecked = CommonUtils.settings.getBoolean("backup_database", false)
             toggleBackupDocuments.isChecked = CommonUtils.settings.getBoolean("backup_documents", false)
             toggleRestoreDatabase.isChecked = CommonUtils.settings.getBoolean("restore_database", false)
             toggleRestoreDocuments.isChecked = CommonUtils.settings.getBoolean("restore_documents", false)
 
-            // update toggles when another toggle is clicked
-            toggleBackupApplication.setOnClickListener {
-                toggleBackupDatabase.isChecked = false
-                toggleBackupDocuments.isChecked = false
-                updateWidgetState() }
-            toggleBackupDatabase.setOnClickListener {
-                toggleBackupApplication.isChecked = false
-                toggleBackupDocuments.isChecked = false
-                updateWidgetState() }
-            toggleBackupDocuments.setOnClickListener {
-                toggleBackupApplication.isChecked = false
-                toggleBackupDatabase.isChecked = false
-                updateWidgetState() }
-            toggleRestoreDatabase.setOnClickListener {
-                toggleRestoreDocuments.isChecked = false
-                updateWidgetState() }
-            toggleRestoreDocuments.setOnClickListener {
-                toggleRestoreDatabase.isChecked = false
-                updateWidgetState() }
             buttonBackup.setOnClickListener {
-                if (toggleBackupApplication.isChecked) GlobalScope.launch { BackupControl.backupApp(this@BackupActivity) }
-                else if (toggleBackupDatabase.isChecked) GlobalScope.launch { BackupControl.startBackupAppDatabase(this@BackupActivity) }
-                else if (toggleBackupDocuments.isChecked) GlobalScope.launch { BackupControl.backupModulesViaIntent(this@BackupActivity) }
+                updateSelectionOptions()
+                when {
+                    toggleBackupApplication.isChecked -> backupScope.launch { BackupControl.backupApp(this@BackupActivity) }
+                    toggleBackupDatabase.isChecked -> backupScope.launch { BackupControl.startBackupAppDatabase(this@BackupActivity) }
+                    toggleBackupDocuments.isChecked -> backupScope.launch { BackupControl.backupModulesViaIntent(this@BackupActivity) }
+                }
             }
             buttonRestore.setOnClickListener {
-                if (toggleRestoreDatabase.isChecked)  GlobalScope.launch { BackupControl.restoreAppDatabaseViaIntent(this@BackupActivity) }
-                else if (toggleRestoreDocuments.isChecked) GlobalScope.launch { BackupControl.restoreModulesViaIntent(this@BackupActivity) }
+                updateSelectionOptions()
+                when {
+                    toggleRestoreDatabase.isChecked -> backupScope.launch { BackupControl.restoreAppDatabaseViaIntent(this@BackupActivity) }
+                    toggleRestoreDocuments.isChecked -> backupScope.launch { BackupControl.restoreModulesViaIntent(this@BackupActivity) }
+                }
             }
             CommonUtils.dbBackupPath.listFiles()?.forEach { f ->
                 val b = Button(this@BackupActivity)
                 val s = f.name
                 b.text = s
                 b.setOnClickListener {
-                    GlobalScope.launch { BackupControl.startBackupOldAppDatabase(this@BackupActivity, f) }
+                    backupScope.launch { BackupControl.startBackupOldAppDatabase(this@BackupActivity, f) }
                 }
                 backupDbButtons.addView(b)
             }
@@ -578,9 +566,7 @@ class BackupActivity: ActivityBase() {
             }
         }
     }
-    private fun updateWidgetState() {
-        updateSelectionOptions()
-    }
+
     private fun updateSelectionOptions() {
         // update widget share option settings
         CommonUtils.settings.apply {

--- a/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
+++ b/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
@@ -529,7 +529,7 @@ class BackupActivity: ActivityBase() {
         binding = BackupViewBinding.inflate(layoutInflater)
         setContentView(binding.root)
         binding.apply {
-            restoreModules.text = "${getString(R.string.install_zip)} / ${getString(R.string.restore_modules)}"
+//            restoreModules.text = "${getString(R.string.install_zip)} / ${getString(R.string.restore_modules)}"
 
             toggleBackupApplication.isChecked = CommonUtils.settings.getBoolean("backup_application", false)
             toggleBackupDatabase.isChecked = CommonUtils.settings.getBoolean("backup_database", false)

--- a/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
+++ b/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
@@ -26,6 +26,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import android.view.MenuItem
 import android.view.View
 import android.widget.Button
 import androidx.core.content.FileProvider
@@ -523,7 +524,27 @@ object BackupControl {
 
 class BackupActivity: ActivityBase() {
     lateinit var binding: BackupViewBinding
-    val backupScope = CoroutineScope(Dispatchers.Default)
+    private val backupScope = CoroutineScope(Dispatchers.Default)
+
+    override fun onBackPressed() {
+        updateSelectionOptions()
+        super.onBackPressed()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        var isHandled = true
+        when(item.itemId){
+            android.R.id.home -> {
+                updateSelectionOptions()
+                finish()
+            }
+            else -> isHandled = false
+        }
+        if (!isHandled) {
+            isHandled = super.onOptionsItemSelected(item)
+        }
+        return isHandled
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
+++ b/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
@@ -531,11 +531,40 @@ class BackupActivity: ActivityBase() {
         binding.apply {
             restoreModules.text = "${getString(R.string.install_zip)} / ${getString(R.string.restore_modules)}"
 
-            backupApp.setOnClickListener { GlobalScope.launch { BackupControl.backupApp(this@BackupActivity) } }
-            backupAppDatabase.setOnClickListener { GlobalScope.launch { BackupControl.startBackupAppDatabase(this@BackupActivity) } }
-            backupModules.setOnClickListener { GlobalScope.launch { BackupControl.backupModulesViaIntent(this@BackupActivity) } }
-            restoreAppDatabase.setOnClickListener { GlobalScope.launch { BackupControl.restoreAppDatabaseViaIntent(this@BackupActivity) } }
-            restoreModules.setOnClickListener { GlobalScope.launch { BackupControl.restoreModulesViaIntent(this@BackupActivity) } }
+            toggleBackupApplication.isChecked = CommonUtils.settings.getBoolean("backup_application", false)
+            toggleBackupDatabase.isChecked = CommonUtils.settings.getBoolean("backup_database", false)
+            toggleBackupDocuments.isChecked = CommonUtils.settings.getBoolean("backup_documents", false)
+            toggleRestoreDatabase.isChecked = CommonUtils.settings.getBoolean("restore_database", false)
+            toggleRestoreDocuments.isChecked = CommonUtils.settings.getBoolean("restore_documents", false)
+
+            // update toggles when another toggle is clicked
+            toggleBackupApplication.setOnClickListener {
+                toggleBackupDatabase.isChecked = false
+                toggleBackupDocuments.isChecked = false
+                updateWidgetState() }
+            toggleBackupDatabase.setOnClickListener {
+                toggleBackupApplication.isChecked = false
+                toggleBackupDocuments.isChecked = false
+                updateWidgetState() }
+            toggleBackupDocuments.setOnClickListener {
+                toggleBackupApplication.isChecked = false
+                toggleBackupDatabase.isChecked = false
+                updateWidgetState() }
+            toggleRestoreDatabase.setOnClickListener {
+                toggleRestoreDocuments.isChecked = false
+                updateWidgetState() }
+            toggleRestoreDocuments.setOnClickListener {
+                toggleRestoreDatabase.isChecked = false
+                updateWidgetState() }
+            buttonBackup.setOnClickListener {
+                if (toggleBackupApplication.isChecked) GlobalScope.launch { BackupControl.backupApp(this@BackupActivity) }
+                else if (toggleBackupDatabase.isChecked) GlobalScope.launch { BackupControl.startBackupAppDatabase(this@BackupActivity) }
+                else if (toggleBackupDocuments.isChecked) GlobalScope.launch { BackupControl.backupModulesViaIntent(this@BackupActivity) }
+            }
+            buttonRestore.setOnClickListener {
+                if (toggleRestoreDatabase.isChecked)  GlobalScope.launch { BackupControl.restoreAppDatabaseViaIntent(this@BackupActivity) }
+                else if (toggleRestoreDocuments.isChecked) GlobalScope.launch { BackupControl.restoreModulesViaIntent(this@BackupActivity) }
+            }
             CommonUtils.dbBackupPath.listFiles()?.forEach { f ->
                 val b = Button(this@BackupActivity)
                 val s = f.name
@@ -548,6 +577,19 @@ class BackupActivity: ActivityBase() {
             if(backupDbButtons.childCount == 0) {
                 importExportTitle.visibility = View.GONE
             }
+        }
+    }
+    private fun updateWidgetState() {
+        updateSelectionOptions()
+    }
+    private fun updateSelectionOptions() {
+        // update widget share option settings
+        CommonUtils.settings.apply {
+            setBoolean("backup_application", binding.toggleBackupApplication.isChecked)
+            setBoolean("backup_database", binding.toggleBackupDatabase.isChecked)
+            setBoolean("backup_documents", binding.toggleBackupDocuments.isChecked)
+            setBoolean("restore_database", binding.toggleRestoreDatabase.isChecked)
+            setBoolean("restore_documents", binding.toggleRestoreDocuments.isChecked)
         }
     }
 }

--- a/app/src/main/res/layout/backup_view.xml
+++ b/app/src/main/res/layout/backup_view.xml
@@ -10,17 +10,104 @@
         android:layout_height="wrap_content"
         android:padding="10dip"
         >
-        <Button
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/backup_app"
-            android:text="@string/backup_app"
-            />
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/backup_button"
-            />
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleBackupApplication"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/application" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:text="@string/application_info" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleBackupDatabase"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/database" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:text="@string/database_info" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleBackupDocuments"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/documents" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:text="@string/document_info" />
+
+        <Button
+            android:id="@+id/buttonBackup"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="50dp"
+            android:layout_marginRight="50dp"
+            android:text="@string/share_or_backup_to" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/restore"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleRestoreDatabase"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/database" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@string/database_info" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleRestoreDocuments"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/documents" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@string/document_info" />
+
+        <Button
+            android:id="@+id/buttonRestore"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="50dp"
+            android:layout_marginRight="50dp"
+            android:text="@string/restore_from" />
+
+        <Button
+            android:id="@+id/backup_app"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/backup_app" />
+
         <Button
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/backup_view.xml
+++ b/app/src/main/res/layout/backup_view.xml
@@ -35,44 +35,49 @@
             android:textSize="20sp"
             android:textStyle="bold" />
 
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/toggleBackupDatabase"
+        <RadioGroup
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:text="@string/database" />
+            android:layout_height="match_parent">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="20dp"
-            android:text="@string/database_info" />
+            <androidx.appcompat.widget.AppCompatRadioButton
+                android:id="@+id/toggleBackupDatabase"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:text="@string/database" />
 
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/toggleBackupDocuments"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:text="@string/documents" />
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:text="@string/database_info" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="20dp"
-            android:text="@string/document_info" />
+            <androidx.appcompat.widget.AppCompatRadioButton
+                android:id="@+id/toggleBackupDocuments"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:text="@string/documents" />
 
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/toggleBackupApplication"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:text="@string/application" />
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:text="@string/document_info" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="20dp"
-            android:text="@string/application_info" />
+            <androidx.appcompat.widget.AppCompatRadioButton
+                android:id="@+id/toggleBackupApplication"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:text="@string/application" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:text="@string/application_info" />
+        </RadioGroup>
         <Button
             android:id="@+id/buttonBackup"
             android:layout_width="match_parent"
@@ -89,33 +94,36 @@
             android:layout_marginTop="20dp"
             android:textSize="20sp"
             android:textStyle="bold" />
-
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/toggleRestoreDatabase"
+        <RadioGroup
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:text="@string/database" />
+            android:layout_height="match_parent">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:text="@string/database_info" />
+            <androidx.appcompat.widget.AppCompatRadioButton
+                android:id="@+id/toggleRestoreDatabase"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:text="@string/database" />
 
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/toggleRestoreDocuments"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:text="@string/documents" />
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:text="@string/database_info" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:text="@string/document_info" />
+            <androidx.appcompat.widget.AppCompatRadioButton
+                android:id="@+id/toggleRestoreDocuments"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:text="@string/documents" />
 
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:text="@string/document_info" />
+        </RadioGroup>
         <Button
             android:id="@+id/buttonRestore"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/backup_view.xml
+++ b/app/src/main/res/layout/backup_view.xml
@@ -19,45 +19,48 @@
             android:textStyle="bold" />
 
         <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/toggleBackupApplication"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/application" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:text="@string/application_info" />
-
-        <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/toggleBackupDatabase"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
             android:text="@string/database" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
+            android:layout_marginLeft="20dp"
             android:text="@string/database_info" />
 
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/toggleBackupDocuments"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
             android:text="@string/documents" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
+            android:layout_marginLeft="20dp"
             android:text="@string/document_info" />
 
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleBackupApplication"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:text="@string/application" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:text="@string/application_info" />
         <Button
             android:id="@+id/buttonBackup"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
             android:layout_marginLeft="50dp"
             android:layout_marginRight="50dp"
             android:text="@string/share_or_backup_to" />
@@ -65,8 +68,8 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
             android:text="@string/restore"
+            android:layout_marginTop="20dp"
             android:textSize="20sp"
             android:textStyle="bold" />
 
@@ -74,74 +77,46 @@
             android:id="@+id/toggleRestoreDatabase"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
             android:text="@string/database" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
+            android:layout_marginStart="20dp"
             android:text="@string/database_info" />
 
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/toggleRestoreDocuments"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
             android:text="@string/documents" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
+            android:layout_marginStart="20dp"
             android:text="@string/document_info" />
 
         <Button
             android:id="@+id/buttonRestore"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
             android:layout_marginLeft="50dp"
             android:layout_marginRight="50dp"
             android:text="@string/restore_from" />
 
-        <Button
-            android:id="@+id/backup_app"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/backup_app" />
 
-        <Button
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/backup_app_database"
-            android:text="@string/backup_app_database"
-            />
-        <Button
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/backup_modules"
-            android:text="@string/backup_modules"
-            />
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/restore_what"
-            />
-        <Button
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/restore_app_database"
-            android:text="@string/restore_app_database"
-            />
-        <Button
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/restore_modules"
-            android:text="@string/restore_modules"
-            />
         <TextView
             android:id="@+id/import_export_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/import_menu"
+            android:layout_marginTop="20dp"
+            android:textSize="20sp"
+            android:textStyle="bold"
             />
         <LinearLayout
             android:id="@+id/backup_db_buttons"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -613,7 +613,7 @@
     <string name="database">Database</string>
     <string name="documents">Documents</string>
     <string name="application_info">Bible Study application file (.APK)</string>
-    <string name="database_info">Bookmarks, labels, notes, study pads, reading plan, workspaces etc</string>
+    <string name="database_info">Bookmarks, labels, notes, study pads, reading plans, workspaces etc</string>
     <string name="document_info">Bibles, commentaries, dictionaries, maps etc</string>
     <string name="share_or_backup_to">Share or backup to...</string>
     <string name="restore_from">Restore from...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -609,6 +609,15 @@
     <string name="backup_app_database">Share or Backup app database to…</string>
 
     <string name="backup_app">Share or Backup app (.apk file) to …</string>
+    <string name="application">Application</string>
+    <string name="database">Database</string>
+    <string name="documents">Documents</string>
+    <string name="application_info">Bible Study application file (.APK)</string>
+    <string name="database_info">Bookmarks, labels, notes, study pads, reading plan, workspaces etc</string>
+    <string name="document_info">Bibles, commentaries, dictionaries, maps etc</string>
+    <string name="share_or_backup_to">Share or backup to...</string>
+    <string name="restore_from">Restore from...</string>
+    <string name="restore">Restore</string>
 
     <!-- What items (study pads, bookmarks etc) user wants to restore from app db backup file? -->
     <string name="restore_what">What do you want to restore?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -630,10 +630,10 @@
     <string name="database">Database</string>
     <string name="documents">Documents</string>
     <string name="application_info">Bible Study application file (.APK)</string>
-    <string name="database_info">Bookmarks, labels, notes, study pads, reading plans, workspaces etc</string>
-    <string name="document_info">Bibles, commentaries, dictionaries, maps etc</string>
-    <string name="share_or_backup_to">Share or backup to...</string>
-    <string name="restore_from">Restore from...</string>
+    <string name="database_info">Bookmarks, labels, notes, study pads, reading plans, workspaces etc.</string>
+    <string name="document_info">Bibles, commentaries, dictionaries, maps etc.</string>
+    <string name="share_or_backup_to">Share or backup to…</string>
+    <string name="restore_from">Restore from…</string>
     <string name="restore">Restore</string>
 
     <!-- What items (study pads, bookmarks etc) user wants to restore from app db backup file? -->


### PR DESCRIPTION
This closes this issue: https://github.com/AndBible/and-bible/issues/1156

The UI just makes the current functionality more obvious. It uses the existing code to save and restore files. I thought it would be nice to try and combine one or more files but I am not sure how necessary that is. I rarely back up more than just the database.

![image](https://user-images.githubusercontent.com/13920678/178280814-55581d87-1a50-41ca-a6c6-ded0b95d9767.png)

I believe I didn't do anything that would have broken this improvement but I am not sure how to check it:
https://github.com/AndBible/and-bible/issues/1801

