### PR TITLE
Remove verse number from first verse when sharing or copying

### DIFF
--- a/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
+++ b/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
@@ -214,7 +214,7 @@ object SwordContentFacade {
         val start = startVerse.slice(0 until min(startOffset, startVerse.length))
 
         var startVerseNumber = ""
-        if (showVerseNumbers && verseTexts.size > 1) {
+        if (showVerseNumbers && !showReferenceAtFront) {
             startVerseNumber = "${selection.verseRange.start.verse}. "
         }
         if (showSelectionOnly && startOffset > 0 && showEllipsis) {

--- a/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
+++ b/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
@@ -214,7 +214,7 @@ object SwordContentFacade {
         val start = startVerse.slice(0 until min(startOffset, startVerse.length))
 
         var startVerseNumber = ""
-        if (showVerseNumbers && !showReferenceAtFront) {
+        if (showVerseNumbers && !showReferenceAtFront && verseTexts.size > 1) {
             startVerseNumber = "${selection.verseRange.start.verse}. "
         }
         if (showSelectionOnly && startOffset > 0 && showEllipsis) {


### PR DESCRIPTION
The first-verse verse number is always shown when the reference is displayed at the end of the verse. If the reference is positioned at the front of the verse, the first-verse verse number is hidden.