### PR TITLE
Resolve "Unsafe use of a nullable receiver" warnings

### DIFF
--- a/app/src/main/java/net/bible/service/common/CommonUtils.kt
+++ b/app/src/main/java/net/bible/service/common/CommonUtils.kt
@@ -385,13 +385,12 @@ object CommonUtils : CommonUtilsBase() {
         Log.i(TAG, "Deleting directory:" + path.absolutePath)
         if (path.exists()) {
             if (path.isDirectory) {
-                val files = path.listFiles()
-                for (i in files.indices) {
-                    if (files[i].isDirectory) {
-                        deleteDirectory(files[i])
+                path.listFiles()?.forEach { file ->
+                    if (file.isDirectory) {
+                        deleteDirectory(file)
                     } else {
-                        files[i].delete()
-                        Log.i(TAG, "Deleted " + files[i])
+                        file.delete()
+                        Log.i(TAG, "Deleted " + file)
                     }
                 }
             }


### PR DESCRIPTION
The Android SDK now annotates java.io.File.listFiles() as nullable.