### PR TITLE
Resolve deprecation warnings regarding StatFS

### DIFF
--- a/app/src/main/java/net/bible/service/common/CommonUtils.kt
+++ b/app/src/main/java/net/bible/service/common/CommonUtils.kt
@@ -344,7 +344,7 @@ object CommonUtils : CommonUtilsBase() {
 
     fun getFreeSpace(path: String): Long {
         val stat = StatFs(path)
-        val bytesAvailable = stat.blockSize.toLong() * stat.availableBlocks.toLong()
+        val bytesAvailable = stat.availableBytes
         Log.i(TAG, "Free space :$bytesAvailable")
         return bytesAvailable
     }


### PR DESCRIPTION
In API 18 the StatFS methods getBlockSize() and getAvailableBlocks()
were deprecated in favor of new methods returning `long` instead of `int`.
Additionally, API 18 added the method getAvailableBytes() which performs
the multiplcation of the block size and available blocks.  Since
AndBible's minSdk is currently 21, that method can be used without
checking the platform's version.