### PR TITLE
Centralize all of the tests of the BuildConfig's FLAVOR

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
 import net.bible.android.BibleApplication
-import net.bible.android.activity.BuildConfig
 import net.bible.android.activity.R
 import net.bible.android.control.backup.BackupControl
 import net.bible.android.control.download.DownloadControl
@@ -55,6 +54,7 @@ import net.bible.android.view.activity.settings.SettingsActivity
 import net.bible.android.view.activity.speak.GeneralSpeakActivity
 import net.bible.android.view.activity.speak.BibleSpeakActivity
 import net.bible.service.common.CommonUtils
+import net.bible.service.common.BuildVariant
 
 import javax.inject.Inject
 
@@ -74,7 +74,8 @@ constructor(private val callingActivity: MainBibleActivity,
             private val windowControl: WindowControl,
             private val downloadControl: DownloadControl,
 ) {
-    private val isSamsung get() = BuildConfig.FLAVOR == "samsung"
+    private inline val isSamsung get() = BuildVariant.isSamsung
+
     /**
      * on Click handlers
      */

--- a/app/src/main/java/net/bible/android/view/activity/settings/SettingsActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/SettingsActivity.kt
@@ -28,9 +28,9 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceDataStore
 import androidx.preference.PreferenceFragmentCompat
-import net.bible.android.activity.BuildConfig
 import net.bible.android.activity.R
 import net.bible.android.view.activity.base.ActivityBase
+import net.bible.service.common.BuildVariant
 import net.bible.service.common.CommonUtils
 import net.bible.service.common.CommonUtils.makeLarger
 import net.bible.service.common.getPreferenceList
@@ -220,7 +220,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         (preferenceScreen.findPreference<EditTextPreference>("discrete_mode") as Preference).apply {
-            if(BuildConfig.FLAVOR == "discrete") {
+            if (BuildVariant.isDiscrete) {
                 isVisible = false
             }
         }

--- a/app/src/main/java/net/bible/service/common/BuildVariantProps.kt
+++ b/app/src/main/java/net/bible/service/common/BuildVariantProps.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020-2022 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
+ *
+ * This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+ *
+ * AndBible is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with AndBible.
+ * If not, see http://www.gnu.org/licenses/.
+ */
+package net.bible.service.common
+
+import net.bible.android.activity.BuildConfig.FLAVOR
+
+object BuildVariant {
+    inline val isDiscrete get() = FLAVOR == "discrete"
+
+    inline val isSamsung get() = FLAVOR == "samsung"
+}
+

--- a/app/src/main/java/net/bible/service/common/CommonUtils.kt
+++ b/app/src/main/java/net/bible/service/common/CommonUtils.kt
@@ -1227,7 +1227,7 @@ object CommonUtils : CommonUtilsBase() {
         }
     }
 
-    val isDiscrete get() = settings.getBoolean("discrete_mode", false) || FLAVOR == "discrete"
+    val isDiscrete get() = settings.getBoolean("discrete_mode", false) || BuildVariant.isDiscrete
 }
 
 @Serializable


### PR DESCRIPTION
Do not repeat the string operations to identify the build's flavor, and centralize all of the string operations in a single file.