### PR TITLE
Memory leak: notify the BibleFrames to unregister from the EventBus

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/screen/SplitBibleArea.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/screen/SplitBibleArea.kt
@@ -151,6 +151,9 @@ class SplitBibleArea: FrameLayout(mainBibleActivity) {
     private val windowRepository = windowControl.windowRepository
 
     fun destroy() {
+        // First explicitly remove the BibleFrames, to explicitly notify them to
+        // unregister from the EventBus
+        removeAllFrames()
         removeAllViews()
         ABEventBus.unregister(this)
         bibleViewFactory.clear()


### PR DESCRIPTION
Run AndBible, then rotate the device a few times.  Using the profiler, observe that several instances of MainBibleActivity have leaked, because the associated BibleFrame objects registered with the ABEventBus but never unregistered from it.