### PR TITLE
Memory leak: notify the BibleGestureListener to unregister from the E…

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/BibleGestureListener.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleGestureListener.kt
@@ -49,6 +49,10 @@ class BibleGestureListener(private val mainBibleActivity: MainBibleActivity) : S
         ABEventBus.register(this)
     }
 
+    fun destroy() {
+        ABEventBus.unregister(this)
+    }
+
     override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
         if (!::flingEv.isInitialized || e1.eventTime > flingEv.eventTime) {
             // New fling event

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
@@ -658,6 +658,7 @@ class BibleView(val mainBibleActivity: MainBibleActivity,
 
     override fun destroy() {
         toBeDestroyed = true
+        gestureListener.destroy()
         pageTiltScroller.destroy()
         removeJavascriptInterface("android")
     }


### PR DESCRIPTION
Run AndBible, then rotate the device a few times.  Using the profiler, observe that several instances of MainBibleActivity have leaked, because the associated BibleGestureListener object registered with the ABEventBus but never unregistered from it.