### PR TITLE
Launch in the activity's lifecycleScope, not GlobalScope

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -304,6 +304,7 @@ dependencies {
     implementation("androidx.media:media:1.6.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
     implementation("androidx.preference:preference:1.2.0")
     implementation("androidx.preference:preference-ktx:1.2.0")
     implementation("androidx.recyclerview:recyclerview:1.2.1")

--- a/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MenuCommandHandler.kt
@@ -28,6 +28,7 @@ import android.util.Log
 import android.view.MenuItem
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
@@ -280,7 +281,7 @@ constructor(private val mainBibleActivity: MainBibleActivity,
 
     private fun openLink(link: String) {
         if (CommonUtils.isDiscrete) {
-            GlobalScope.launch (Dispatchers.Main){
+            mainBibleActivity.lifecycleScope.launch(Dispatchers.Main) {
                 if(Dialogs.simpleQuestion(mainBibleActivity,
                         application.getString(R.string.external_link),
                         application.getString(R.string.external_link_question, link))


### PR DESCRIPTION
This will ensure that the job is canceled when the activity is destroyed.  Jobs that are launched in the GlobalScope are leaked if they do not complete and are not otherwise explicitly canceled. This job is leaked in the GlobalScope when the device is rotated while the confirmation dialog is displayed, because it neither completes nor is canceled.  When launched in the activity's lifecycleScope, it is canceled when the activity is destroyed, due to device rotation, while the confirmation dialog is displayed.
(#2316)
