### PR TITLE
Compact bookmark list view

### DIFF
--- a/app/src/main/res/layout/bookmark_list_item.xml
+++ b/app/src/main/res/layout/bookmark_list_item.xml
@@ -50,11 +50,13 @@
             <TextView android:id="@+id/verseText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:textAppearance="?attr/textAppearanceListItem"
                 />
             <TextView android:id="@+id/dateText"
-                android:layout_width="fill_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:gravity="end"
                 />
         </LinearLayout>


### PR DESCRIPTION
Under certain conditions, probably when both the reference and the timestamp are too long and with a large-enough font, the bookmark list view splits the space unevenly - the reference gets too much space and the timestamp therefore needs many lines. Fix this by splitting the space more evenly.

Fix #2343 .