### PR TITLE
Replace hard-coded URLs of SWORD repositories

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/download/DownloadActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/download/DownloadActivity.kt
@@ -67,6 +67,8 @@ import kotlinx.serialization.serializer
 import net.bible.android.database.SwordDocumentInfo
 import net.bible.android.view.activity.base.Dialogs
 import net.bible.service.common.CommonUtils
+import net.bible.service.download.urlPrefix
+import java.text.Collator
 
 /**
  * Choose Document (Book) to download
@@ -297,13 +299,10 @@ open class DownloadActivity : DocumentSelectionBase(R.menu.download_documents, R
     }
 
     override fun showPreLoadMessage(refresh: Boolean) {
-        val repositories = """
-                https://crosswire.org
-                https://ibtrussia.org
-                https://ebible.org
-                https://public.modules.stepbible.org
-                https://andbible.github.io
-                """.trimIndent()
+        val repositories = repoFactory.repositories.asSequence()
+            .mapNotNull { downloadManager.getInstallerFor(it)?.urlPrefix }
+            .toSortedSet( Collator.getInstance() )
+            .joinToString("\n")
 
         val repoRefreshDate = settings.getLong(REPO_REFRESH_DATE, 0)
         val date = SimpleDateFormat.getDateInstance().format(Date(repoRefreshDate))

--- a/app/src/main/java/net/bible/service/download/DownloadManager.kt
+++ b/app/src/main/java/net/bible/service/download/DownloadManager.kt
@@ -55,6 +55,9 @@ class DownloadManager(
         onFailedReposChange?.invoke()
     }
 
+    fun getInstallerFor(repo: RepoBase): Installer?
+        = installManager.getInstaller(repo.repoName)
+
     @Throws(InstallException::class)
     fun getDownloadableBooks(filter: BookFilter?, repo: String, refresh: Boolean): List<Book> {
         var documents: List<Book> = emptyList()

--- a/app/src/main/java/net/bible/service/download/RepositoriesExt.kt
+++ b/app/src/main/java/net/bible/service/download/RepositoriesExt.kt
@@ -1,0 +1,27 @@
+package net.bible.service.download
+
+import org.crosswire.jsword.book.install.Installer
+import org.crosswire.jsword.book.install.sword.AbstractSwordInstaller
+
+/**
+ * The [RepoBase] data structure does not contain the URL of the repository.
+ * Instead, the URL is computed by JSword's [Installer] implementations,
+ * but unfortunately it does not provide a direct accessor to obtain it.
+ * This extension property uses available information to re-compute the URL.
+ */
+val Installer.urlPrefix: String? get()
+    {
+    // base implementation class, necessary to access properties not declared
+    // by the interface
+    if (this !is AbstractSwordInstaller)
+        { return null }
+
+    val protocol = when (type)
+        {
+        "sword-http" -> "http"
+        "sword-https" -> "https"
+        else -> null
+        }
+
+    return protocol?.let { "${protocol}://${host}/" }
+    }


### PR DESCRIPTION
Compute the (base) URLs for the configured SWORD repositories to display in the Toast message to the user.

The only effect that users should notice, from this change, is that the URLs are now sorted.  This relates to #39.  I have some subsequent changes that I am preparing to submit.
