### PR TITLE
Refactor repositories

### DIFF
--- a/app/src/main/java/net/bible/android/control/download/DownloadQueue.kt
+++ b/app/src/main/java/net/bible/android/control/download/DownloadQueue.kt
@@ -25,7 +25,7 @@ import net.bible.android.control.event.documentdownload.DocumentDownloadEvent
 import net.bible.android.view.activity.base.Dialogs
 import net.bible.service.common.Logger
 import net.bible.service.download.DownloadManager
-import net.bible.service.download.RepoBase
+import net.bible.service.download.Repository
 import org.crosswire.jsword.book.Book
 import org.crosswire.jsword.book.install.DownloadCancelledException
 import org.crosswire.jsword.book.install.DownloadException
@@ -52,7 +52,7 @@ class DownloadQueue {
         return application.getString(msgId)
     }
 
-    suspend fun addDocumentToDownloadQueue(document: Book, repo: RepoBase) {
+    suspend fun addDocumentToDownloadQueue(document: Book, repo: Repository) {
         val repoIdentity = document.repoIdentity
         if (!beingQueued.contains(repoIdentity)) {
             beingQueued.add(repoIdentity)

--- a/app/src/main/java/net/bible/service/download/RepoFactory.kt
+++ b/app/src/main/java/net/bible/service/download/RepoFactory.kt
@@ -40,10 +40,10 @@ class RepoFactory(val downloadManager: DownloadManager) {
         }
     }
 
-    fun getRepoForBook(document: Book): RepoBase {
+    fun getRepoForBook(document: Book): Repository {
         return getRepo(document.getProperty(DownloadManager.REPOSITORY_KEY))
     }
 
-    private fun getRepo(repoName: String): RepoBase =
+    private fun getRepo(repoName: String): Repository =
         repositories.find { it.repoName == repoName } ?: defaultRepo
 }

--- a/app/src/main/java/net/bible/service/download/Repositories.kt
+++ b/app/src/main/java/net/bible/service/download/Repositories.kt
@@ -26,12 +26,17 @@ import org.crosswire.jsword.book.sword.SwordBookMetaData
 
 abstract class RepoBase(
     val repoName: String,
+    private val supportedDocumentsFilter: BookFilter,
     ) {
     lateinit var repoFactory: RepoFactory
 
     private val downloadManager get() = repoFactory.downloadManager
 
-    abstract fun getRepoBooks(refresh: Boolean): List<Book>
+    fun getRepoBooks(refresh: Boolean): List<Book> {
+        val bookList = getBookList(supportedDocumentsFilter, refresh)
+        storeRepoNameInMetaData(bookList)
+        return bookList
+    }
 
     fun getBookList(bookFilter: BookFilter, refresh: Boolean): List<Book> {
         return downloadManager.getDownloadableBooks(bookFilter, repoName, refresh)
@@ -54,52 +59,28 @@ abstract class RepoBase(
     }
 }
 
-class AndBibleRepo : RepoBase(REPOSITORY) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val bookList = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(bookList)
-        return bookList
-    }
-
+class AndBibleRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
     companion object {
         private const val REPOSITORY = "AndBible"
         private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
     }
 }
 
-class StepRepo : RepoBase(REPOSITORY) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val bookList = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(bookList)
-        return bookList
-    }
-
+class StepRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
     companion object {
         private const val REPOSITORY = "STEP Bible (Tyndale)"
         private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
     }
 }
 
-class AndBibleExtraRepo : RepoBase(REPOSITORY) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val bookList = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(bookList)
-        return bookList
-    }
-
+class AndBibleExtraRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
     companion object {
         private const val REPOSITORY = "AndBible Extra"
         private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
     }
 }
 
-class AndBibleBetaRepo : RepoBase(REPONAME) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val books: List<Book> = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(books)
-        return books
-    }
-
+class AndBibleBetaRepo : RepoBase(REPONAME, SUPPORTED_DOCUMENTS) {
     private class BetaBookFilter : AcceptableBookTypeFilter() {
         override fun test(book: Book): Boolean = CommonUtils.isBeta
     }
@@ -111,13 +92,7 @@ class AndBibleBetaRepo : RepoBase(REPONAME) {
 }
 
 
-class CrosswireBetaRepo : RepoBase(REPONAME) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val books: List<Book> = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(books)
-        return books
-    }
-
+class CrosswireBetaRepo : RepoBase(REPONAME, SUPPORTED_DOCUMENTS) {
     private class BetaBookFilter : AcceptableBookTypeFilter() {
         override fun test(book: Book): Boolean {
             // just Calvin Commentaries for now to see how we go
@@ -135,13 +110,7 @@ class CrosswireBetaRepo : RepoBase(REPONAME) {
     }
 }
 
-class CrosswireRepo : RepoBase(REPOSITORY) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val books = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(books)
-        return books
-    }
-
+class CrosswireRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
     companion object {
         // see here for info ftp://ftp.xiphos.org/mods.d/
         private const val REPOSITORY = "CrossWire"
@@ -149,39 +118,21 @@ class CrosswireRepo : RepoBase(REPOSITORY) {
     }
 }
 
-class LockmanRepo : RepoBase(REPOSITORY) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val books = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(books)
-        return books
-    }
-
+class LockmanRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
     companion object {
         private const val REPOSITORY = "Lockman (CrossWire)"
         private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
     }
 }
 
-class WycliffeRepo : RepoBase(REPOSITORY) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val books = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(books)
-        return books
-    }
-
+class WycliffeRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
     companion object {
         private const val REPOSITORY = "Wycliffe (CrossWire)"
         private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
     }
 }
 
-class EBibleRepo : RepoBase(REPOSITORY) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val bookList = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(bookList)
-        return bookList
-    }
-
+class EBibleRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
     companion object {
         const val REPOSITORY = "eBible"
         private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
@@ -189,13 +140,7 @@ class EBibleRepo : RepoBase(REPOSITORY) {
     }
 }
 
-class IBTRepo : RepoBase(REPOSITORY) {
-    override fun getRepoBooks(refresh: Boolean): List<Book> {
-        val books = getBookList(SUPPORTED_DOCUMENTS, refresh)
-        storeRepoNameInMetaData(books)
-        return books
-    }
-
+class IBTRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
     companion object {
         const val REPOSITORY = "IBT"
         private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()

--- a/app/src/main/java/net/bible/service/download/Repositories.kt
+++ b/app/src/main/java/net/bible/service/download/Repositories.kt
@@ -24,13 +24,14 @@ import org.crosswire.jsword.book.BookFilter
 import org.crosswire.jsword.book.sword.SwordBook
 import org.crosswire.jsword.book.sword.SwordBookMetaData
 
-abstract class RepoBase {
+abstract class RepoBase(
+    val repoName: String,
+    ) {
     lateinit var repoFactory: RepoFactory
 
     private val downloadManager get() = repoFactory.downloadManager
 
     abstract fun getRepoBooks(refresh: Boolean): List<Book>
-    abstract val repoName: String
 
     fun getBookList(bookFilter: BookFilter, refresh: Boolean): List<Book> {
         return downloadManager.getDownloadableBooks(bookFilter, repoName, refresh)
@@ -53,14 +54,12 @@ abstract class RepoBase {
     }
 }
 
-class AndBibleRepo : RepoBase() {
+class AndBibleRepo : RepoBase(REPOSITORY) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val bookList = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(bookList)
         return bookList
     }
-
-    override val repoName: String get() = REPOSITORY
 
     companion object {
         private const val REPOSITORY = "AndBible"
@@ -68,14 +67,12 @@ class AndBibleRepo : RepoBase() {
     }
 }
 
-class StepRepo : RepoBase() {
+class StepRepo : RepoBase(REPOSITORY) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val bookList = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(bookList)
         return bookList
     }
-
-    override val repoName: String get() = REPOSITORY
 
     companion object {
         private const val REPOSITORY = "STEP Bible (Tyndale)"
@@ -83,14 +80,12 @@ class StepRepo : RepoBase() {
     }
 }
 
-class AndBibleExtraRepo : RepoBase() {
+class AndBibleExtraRepo : RepoBase(REPOSITORY) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val bookList = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(bookList)
         return bookList
     }
-
-    override val repoName: String get() = REPOSITORY
 
     companion object {
         private const val REPOSITORY = "AndBible Extra"
@@ -98,15 +93,12 @@ class AndBibleExtraRepo : RepoBase() {
     }
 }
 
-class AndBibleBetaRepo : RepoBase() {
+class AndBibleBetaRepo : RepoBase(REPONAME) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val books: List<Book> = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(books)
         return books
     }
-
-    override val repoName: String
-        get() = REPONAME
 
     private class BetaBookFilter : AcceptableBookTypeFilter() {
         override fun test(book: Book): Boolean = CommonUtils.isBeta
@@ -119,15 +111,12 @@ class AndBibleBetaRepo : RepoBase() {
 }
 
 
-class CrosswireBetaRepo : RepoBase() {
+class CrosswireBetaRepo : RepoBase(REPONAME) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val books: List<Book> = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(books)
         return books
     }
-
-    override val repoName: String
-        get() = REPONAME
 
     private class BetaBookFilter : AcceptableBookTypeFilter() {
         override fun test(book: Book): Boolean {
@@ -146,14 +135,12 @@ class CrosswireBetaRepo : RepoBase() {
     }
 }
 
-class CrosswireRepo : RepoBase() {
+class CrosswireRepo : RepoBase(REPOSITORY) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val books = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(books)
         return books
     }
-
-    override val repoName: String get() = REPOSITORY
 
     companion object {
         // see here for info ftp://ftp.xiphos.org/mods.d/
@@ -162,14 +149,12 @@ class CrosswireRepo : RepoBase() {
     }
 }
 
-class LockmanRepo : RepoBase() {
+class LockmanRepo : RepoBase(REPOSITORY) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val books = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(books)
         return books
     }
-
-    override val repoName: String get() = REPOSITORY
 
     companion object {
         private const val REPOSITORY = "Lockman (CrossWire)"
@@ -177,14 +162,12 @@ class LockmanRepo : RepoBase() {
     }
 }
 
-class WycliffeRepo : RepoBase() {
+class WycliffeRepo : RepoBase(REPOSITORY) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val books = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(books)
         return books
     }
-
-    override val repoName: String get() = REPOSITORY
 
     companion object {
         private const val REPOSITORY = "Wycliffe (CrossWire)"
@@ -192,14 +175,12 @@ class WycliffeRepo : RepoBase() {
     }
 }
 
-class EBibleRepo : RepoBase() {
+class EBibleRepo : RepoBase(REPOSITORY) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val bookList = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(bookList)
         return bookList
     }
-
-    override val repoName: String get() = REPOSITORY
 
     companion object {
         const val REPOSITORY = "eBible"
@@ -208,14 +189,12 @@ class EBibleRepo : RepoBase() {
     }
 }
 
-class IBTRepo : RepoBase() {
+class IBTRepo : RepoBase(REPOSITORY) {
     override fun getRepoBooks(refresh: Boolean): List<Book> {
         val books = getBookList(SUPPORTED_DOCUMENTS, refresh)
         storeRepoNameInMetaData(books)
         return books
     }
-
-    override val repoName: String get() = REPOSITORY
 
     companion object {
         const val REPOSITORY = "IBT"

--- a/app/src/main/java/net/bible/service/download/Repositories.kt
+++ b/app/src/main/java/net/bible/service/download/Repositories.kt
@@ -24,7 +24,7 @@ import org.crosswire.jsword.book.BookFilter
 import org.crosswire.jsword.book.sword.SwordBook
 import org.crosswire.jsword.book.sword.SwordBookMetaData
 
-abstract class RepoBase(
+class RepoBase(
     val repoName: String,
     private val supportedDocumentsFilter: BookFilter,
     ) {
@@ -59,41 +59,23 @@ abstract class RepoBase(
     }
 }
 
-class AndBibleRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
-    companion object {
-        private const val REPOSITORY = "AndBible"
-        private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
-    }
-}
+fun AndBibleRepo() = RepoBase("AndBible", AcceptableBookTypeFilter())
 
-class StepRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
-    companion object {
-        private const val REPOSITORY = "STEP Bible (Tyndale)"
-        private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
-    }
-}
+fun StepRepo() = RepoBase("STEP Bible (Tyndale)", AcceptableBookTypeFilter())
 
-class AndBibleExtraRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
-    companion object {
-        private const val REPOSITORY = "AndBible Extra"
-        private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
-    }
-}
+fun AndBibleExtraRepo() = RepoBase("AndBible Extra", AcceptableBookTypeFilter())
 
-class AndBibleBetaRepo : RepoBase(REPONAME, SUPPORTED_DOCUMENTS) {
-    private class BetaBookFilter : AcceptableBookTypeFilter() {
+fun AndBibleBetaRepo() = RepoBase(
+    "AndBible Beta",
+    object: AcceptableBookTypeFilter() {
         override fun test(book: Book): Boolean = CommonUtils.isBeta
     }
-
-    companion object {
-        const val REPONAME = "AndBible Beta"
-        private val SUPPORTED_DOCUMENTS: BookFilter = BetaBookFilter()
-    }
-}
+    )
 
 
-class CrosswireBetaRepo : RepoBase(REPONAME, SUPPORTED_DOCUMENTS) {
-    private class BetaBookFilter : AcceptableBookTypeFilter() {
+fun CrosswireBetaRepo() = RepoBase(
+    "Crosswire Beta",
+    object : AcceptableBookTypeFilter() {
         override fun test(book: Book): Boolean {
             // just Calvin Commentaries for now to see how we go
             //
@@ -103,47 +85,15 @@ class CrosswireBetaRepo : RepoBase(REPONAME, SUPPORTED_DOCUMENTS) {
                 book.initials == "CalvinCommentaries"
         }
     }
+    )
 
-    companion object {
-        const val REPONAME = "Crosswire Beta"
-        private val SUPPORTED_DOCUMENTS: BookFilter = BetaBookFilter()
-    }
-}
-
-class CrosswireRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
-    companion object {
         // see here for info ftp://ftp.xiphos.org/mods.d/
-        private const val REPOSITORY = "CrossWire"
-        private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
-    }
-}
+fun CrosswireRepo() = RepoBase("CrossWire", AcceptableBookTypeFilter())
 
-class LockmanRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
-    companion object {
-        private const val REPOSITORY = "Lockman (CrossWire)"
-        private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
-    }
-}
+fun LockmanRepo() = RepoBase("Lockman (CrossWire)", AcceptableBookTypeFilter())
 
-class WycliffeRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
-    companion object {
-        private const val REPOSITORY = "Wycliffe (CrossWire)"
-        private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
-    }
-}
+fun WycliffeRepo() = RepoBase("Wycliffe (CrossWire)", AcceptableBookTypeFilter())
 
-class EBibleRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
-    companion object {
-        const val REPOSITORY = "eBible"
-        private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
-        private const val TAG = "EBibleRepo"
-    }
-}
+fun EBibleRepo() = RepoBase("eBible", AcceptableBookTypeFilter())
 
-class IBTRepo : RepoBase(REPOSITORY, SUPPORTED_DOCUMENTS) {
-    companion object {
-        const val REPOSITORY = "IBT"
-        private val SUPPORTED_DOCUMENTS: BookFilter = AcceptableBookTypeFilter()
-    }
-}
-
+fun IBTRepo() = RepoBase("IBT", AcceptableBookTypeFilter())

--- a/app/src/main/java/net/bible/service/download/Repositories.kt
+++ b/app/src/main/java/net/bible/service/download/Repositories.kt
@@ -24,7 +24,7 @@ import org.crosswire.jsword.book.BookFilter
 import org.crosswire.jsword.book.sword.SwordBook
 import org.crosswire.jsword.book.sword.SwordBookMetaData
 
-class RepoBase(
+class Repository(
     val repoName: String,
     private val supportedDocumentsFilter: BookFilter,
     ) {
@@ -59,13 +59,13 @@ class RepoBase(
     }
 }
 
-fun AndBibleRepo() = RepoBase("AndBible", AcceptableBookTypeFilter())
+fun AndBibleRepo() = Repository("AndBible", AcceptableBookTypeFilter())
 
-fun StepRepo() = RepoBase("STEP Bible (Tyndale)", AcceptableBookTypeFilter())
+fun StepRepo() = Repository("STEP Bible (Tyndale)", AcceptableBookTypeFilter())
 
-fun AndBibleExtraRepo() = RepoBase("AndBible Extra", AcceptableBookTypeFilter())
+fun AndBibleExtraRepo() = Repository("AndBible Extra", AcceptableBookTypeFilter())
 
-fun AndBibleBetaRepo() = RepoBase(
+fun AndBibleBetaRepo() = Repository(
     "AndBible Beta",
     object: AcceptableBookTypeFilter() {
         override fun test(book: Book): Boolean = CommonUtils.isBeta
@@ -73,7 +73,7 @@ fun AndBibleBetaRepo() = RepoBase(
     )
 
 
-fun CrosswireBetaRepo() = RepoBase(
+fun CrosswireBetaRepo() = Repository(
     "Crosswire Beta",
     object : AcceptableBookTypeFilter() {
         override fun test(book: Book): Boolean {
@@ -88,12 +88,12 @@ fun CrosswireBetaRepo() = RepoBase(
     )
 
         // see here for info ftp://ftp.xiphos.org/mods.d/
-fun CrosswireRepo() = RepoBase("CrossWire", AcceptableBookTypeFilter())
+fun CrosswireRepo() = Repository("CrossWire", AcceptableBookTypeFilter())
 
-fun LockmanRepo() = RepoBase("Lockman (CrossWire)", AcceptableBookTypeFilter())
+fun LockmanRepo() = Repository("Lockman (CrossWire)", AcceptableBookTypeFilter())
 
-fun WycliffeRepo() = RepoBase("Wycliffe (CrossWire)", AcceptableBookTypeFilter())
+fun WycliffeRepo() = Repository("Wycliffe (CrossWire)", AcceptableBookTypeFilter())
 
-fun EBibleRepo() = RepoBase("eBible", AcceptableBookTypeFilter())
+fun EBibleRepo() = Repository("eBible", AcceptableBookTypeFilter())
 
-fun IBTRepo() = RepoBase("IBT", AcceptableBookTypeFilter())
+fun IBTRepo() = Repository("IBT", AcceptableBookTypeFilter())


### PR DESCRIPTION
I moved duplicate code from the subclasses to the base class, added constructor parameters, and then converted the subclasses to factory functions.  This simplifies and shortens the code.  Related to #39.