### PR TITLE
Declare the same version of kotlinx-coroutines-android in :db

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -294,6 +294,7 @@ dependencies {
     val jdomVersion: String by rootProject.extra
     val jswordVersion: String by rootProject.extra
     val kotlinVersion: String by rootProject.extra
+    val coroutinesVersion: String by rootProject.extra
     val kotlinxSerializationVersion: String by rootProject.extra
     val roomVersion: String by rootProject.extra
 
@@ -323,7 +324,7 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${coroutinesVersion}")
 
     implementation("com.madgag.spongycastle:core:1.58.0.0")
     //implementation("com.madgag.spongycastle:prov:1.58.0.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@
 
 buildscript {
     val kotlinVersion by extra("1.7.20")
+    val coroutinesVersion by extra("1.6.4")
     val roomVersion by extra("2.4.3")
     val jswordVersion by extra("2.3.68")
     val jdomVersion by extra("2.0.6") // make sure this is same version as in jsword!

--- a/db/build.gradle.kts
+++ b/db/build.gradle.kts
@@ -53,6 +53,7 @@ android {
 }
 
 dependencies {
+    val coroutinesVersion: String by rootProject.extra
     val commonsTextVersion: String by rootProject.extra
     val jdomVersion: String by rootProject.extra
     val jswordVersion: String by rootProject.extra
@@ -61,6 +62,7 @@ dependencies {
 
     implementation("androidx.room:room-runtime:$roomVersion")
     implementation("androidx.room:room-ktx:$roomVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${coroutinesVersion}")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
     implementation("com.github.AndBible:jsword:$jswordVersion")
     implementation("org.jdom:jdom2:$jdomVersion")


### PR DESCRIPTION
Declare dependencies on the same version of kotlinx-coroutines-android in the :app and :db gradle subprojects.  The :db subproject already included an older version (v1.5.2) as a transitive dependency of room-ktx (v2.4.3).