### PR TITLE
Move the repository global variables into RepoFactory

### DIFF
--- a/app/src/main/java/net/bible/service/download/RepoFactory.kt
+++ b/app/src/main/java/net/bible/service/download/RepoFactory.kt
@@ -24,22 +24,23 @@ import org.crosswire.jsword.book.Book
 /**
  * @author Martin Denham [mjdenham at gmail dot com]
  */
-class RepoFactory(val downloadManager: DownloadManager) {
+class RepoFactory(downloadManager: DownloadManager) {
 
-    private val andBibleRepo = Repository("AndBible", AcceptableBookTypeFilter())
-    private val andBibleExtraRepo = Repository("AndBible Extra", AcceptableBookTypeFilter())
+    private val andBibleRepo = Repository("AndBible", AcceptableBookTypeFilter(), downloadManager)
+    private val andBibleExtraRepo = Repository("AndBible Extra", AcceptableBookTypeFilter(), downloadManager)
     private val andBibleBetaRepo = Repository(
         "AndBible Beta",
         object: AcceptableBookTypeFilter() {
             override fun test(book: Book): Boolean = CommonUtils.isBeta
         }
+        , downloadManager
     )
 
     // see here for info ftp://ftp.xiphos.org/mods.d/
     @VisibleForTesting
-    val crosswireRepo = Repository("CrossWire", AcceptableBookTypeFilter())
-    private val lockmanRepo = Repository("Lockman (CrossWire)", AcceptableBookTypeFilter())
-    private val wycliffeRepo = Repository("Wycliffe (CrossWire)", AcceptableBookTypeFilter())
+    val crosswireRepo = Repository("CrossWire", AcceptableBookTypeFilter(), downloadManager)
+    private val lockmanRepo = Repository("Lockman (CrossWire)", AcceptableBookTypeFilter(), downloadManager)
+    private val wycliffeRepo = Repository("Wycliffe (CrossWire)", AcceptableBookTypeFilter(), downloadManager)
     private val crosswireBetaRepo = Repository(
         "Crosswire Beta",
         object : AcceptableBookTypeFilter() {
@@ -52,11 +53,12 @@ class RepoFactory(val downloadManager: DownloadManager) {
                     book.initials == "CalvinCommentaries"
             }
         }
+        , downloadManager
     )
 
-    private val eBibleRepo = Repository("eBible", AcceptableBookTypeFilter())
-    private val stepRepo = Repository("STEP Bible (Tyndale)", AcceptableBookTypeFilter())
-    private val ibtRepo = Repository("IBT", AcceptableBookTypeFilter())
+    private val eBibleRepo = Repository("eBible", AcceptableBookTypeFilter(), downloadManager)
+    private val stepRepo = Repository("STEP Bible (Tyndale)", AcceptableBookTypeFilter(), downloadManager)
+    private val ibtRepo = Repository("IBT", AcceptableBookTypeFilter(), downloadManager)
 
 
     private val defaultRepo = andBibleRepo
@@ -70,12 +72,6 @@ class RepoFactory(val downloadManager: DownloadManager) {
     val betaRepositories = listOf(crosswireBetaRepo, andBibleBetaRepo)
 
     val repositories = normalRepositories + betaRepositories
-
-    init {
-        for(r in repositories) {
-            r.repoFactory = this
-        }
-    }
 
     fun getRepoForBook(document: Book): Repository {
         return getRepo(document.getProperty(DownloadManager.REPOSITORY_KEY))

--- a/app/src/main/java/net/bible/service/download/RepoFactory.kt
+++ b/app/src/main/java/net/bible/service/download/RepoFactory.kt
@@ -16,12 +16,49 @@
  */
 package net.bible.service.download
 
+import androidx.annotation.VisibleForTesting
+import net.bible.service.common.CommonUtils
+import net.bible.service.sword.AcceptableBookTypeFilter
 import org.crosswire.jsword.book.Book
 
 /**
  * @author Martin Denham [mjdenham at gmail dot com]
  */
 class RepoFactory(val downloadManager: DownloadManager) {
+
+    private val andBibleRepo = Repository("AndBible", AcceptableBookTypeFilter())
+    private val andBibleExtraRepo = Repository("AndBible Extra", AcceptableBookTypeFilter())
+    private val andBibleBetaRepo = Repository(
+        "AndBible Beta",
+        object: AcceptableBookTypeFilter() {
+            override fun test(book: Book): Boolean = CommonUtils.isBeta
+        }
+    )
+
+    // see here for info ftp://ftp.xiphos.org/mods.d/
+    @VisibleForTesting
+    val crosswireRepo = Repository("CrossWire", AcceptableBookTypeFilter())
+    private val lockmanRepo = Repository("Lockman (CrossWire)", AcceptableBookTypeFilter())
+    private val wycliffeRepo = Repository("Wycliffe (CrossWire)", AcceptableBookTypeFilter())
+    private val crosswireBetaRepo = Repository(
+        "Crosswire Beta",
+        object : AcceptableBookTypeFilter() {
+            override fun test(book: Book): Boolean {
+                // just Calvin Commentaries for now to see how we go
+                //
+                // Cannot include Jasher, Jub, EEnochCharles because they are displayed as page per verse for some reason which looks awful.
+                if(CommonUtils.isBeta) return true
+                return super.test(book) &&
+                    book.initials == "CalvinCommentaries"
+            }
+        }
+    )
+
+    private val eBibleRepo = Repository("eBible", AcceptableBookTypeFilter())
+    private val stepRepo = Repository("STEP Bible (Tyndale)", AcceptableBookTypeFilter())
+    private val ibtRepo = Repository("IBT", AcceptableBookTypeFilter())
+
+
     private val defaultRepo = andBibleRepo
 
     // In priority order (if the same version of module is found in many, it will be picked up

--- a/app/src/main/java/net/bible/service/download/Repositories.kt
+++ b/app/src/main/java/net/bible/service/download/Repositories.kt
@@ -25,10 +25,8 @@ import org.crosswire.jsword.book.sword.SwordBookMetaData
 class Repository(
     val repoName: String,
     private val supportedDocumentsFilter: BookFilter,
+    private val downloadManager: DownloadManager,
 ) {
-    lateinit var repoFactory: RepoFactory
-
-    private val downloadManager get() = repoFactory.downloadManager
 
     fun getRepoBooks(refresh: Boolean): List<Book> {
         val bookList = getBookList(supportedDocumentsFilter, refresh)

--- a/app/src/main/java/net/bible/service/download/Repositories.kt
+++ b/app/src/main/java/net/bible/service/download/Repositories.kt
@@ -17,8 +17,6 @@
 
 package net.bible.service.download
 
-import net.bible.service.common.CommonUtils
-import net.bible.service.sword.AcceptableBookTypeFilter
 import org.crosswire.jsword.book.Book
 import org.crosswire.jsword.book.BookFilter
 import org.crosswire.jsword.book.sword.SwordBook
@@ -58,35 +56,3 @@ class Repository(
         }
     }
 }
-
-val andBibleRepo = Repository("AndBible", AcceptableBookTypeFilter())
-val stepRepo = Repository("STEP Bible (Tyndale)", AcceptableBookTypeFilter())
-val andBibleExtraRepo = Repository("AndBible Extra", AcceptableBookTypeFilter())
-val andBibleBetaRepo = Repository(
-    "AndBible Beta",
-    object: AcceptableBookTypeFilter() {
-        override fun test(book: Book): Boolean = CommonUtils.isBeta
-    }
-)
-
-
-val crosswireBetaRepo = Repository(
-    "Crosswire Beta",
-    object : AcceptableBookTypeFilter() {
-        override fun test(book: Book): Boolean {
-            // just Calvin Commentaries for now to see how we go
-            //
-            // Cannot include Jasher, Jub, EEnochCharles because they are displayed as page per verse for some reason which looks awful.
-            if(CommonUtils.isBeta) return true
-            return super.test(book) &&
-                book.initials == "CalvinCommentaries"
-        }
-    }
-)
-
-// see here for info ftp://ftp.xiphos.org/mods.d/
-val crosswireRepo = Repository("CrossWire", AcceptableBookTypeFilter())
-val lockmanRepo = Repository("Lockman (CrossWire)", AcceptableBookTypeFilter())
-val wycliffeRepo = Repository("Wycliffe (CrossWire)", AcceptableBookTypeFilter())
-val eBibleRepo = Repository("eBible", AcceptableBookTypeFilter())
-val ibtRepo = Repository("IBT", AcceptableBookTypeFilter())

--- a/app/src/test/java/net/bible/service/download/CrosswireRepoIT.kt
+++ b/app/src/test/java/net/bible/service/download/CrosswireRepoIT.kt
@@ -34,11 +34,13 @@ import org.robolectric.annotation.Config
 @Config(sdk=[TEST_SDK])
 class CrosswireRepoIT {
 
+    private lateinit var crosswireRepo: Repository
+
     @Before
     @Throws(Exception::class)
     fun setUp() {
         val repoFactory = RepoFactory(DownloadManager(null))
-        crosswireRepo.repoFactory = repoFactory
+        crosswireRepo = repoFactory.crosswireRepo
     }
 
     @Test


### PR DESCRIPTION
Allow RepoFactory to retain responsibility for creating the repository objects, and allow the objects to be garbage collected when they are not in use.

Also,  reduce coupling by passing the DownloadManager to the Repository constructor.  This eliminates the dependency from Repository to RepoFactory, which was used solely to obtain a reference to the DownloadManager.
