### PR TITLE
Don't show the window buttons when scrolling

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/BibleGestureListener.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleGestureListener.kt
@@ -103,7 +103,6 @@ class BibleGestureListener(private val mainBibleActivity: MainBibleActivity) : S
             // New scroll event
             scrollEv = MotionEvent.obtain(e1)
         }
-        ABEventBus.post(BibleView.BibleViewTouched(onlyTouch = true))
         if (e2.eventTime - scrollEv.eventTime > 1000) {
             // Too slow motion
             scrollEv = MotionEvent.obtain(e2)


### PR DESCRIPTION
One thing that has bugged me for a while is that everytime I scroll each window button becomes visible. I dont think there is ever a good reason to show those buttons when scrolling. When they do appear they obscure the text that I am scrolling through and trying to read.

This change simply disables this feature. The buttons still show on click events and when a window becomes active which is exactly what I want.