### PR TITLE
Fix problematic coroutine of startPlan

### DIFF
--- a/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanRepository.kt
+++ b/app/src/main/java/net/bible/service/db/readingplan/ReadingPlanRepository.kt
@@ -63,7 +63,7 @@ class ReadingPlanRepository @Inject constructor() {
     }
 
     @Synchronized
-    fun startPlan(planCode: String, date: Date = CommonUtils.truncatedDate) = scope.launch {
+    fun startPlan(planCode: String, date: Date = CommonUtils.truncatedDate) = runBlocking {
         var readPlan = readingPlanDao.getPlan(planCode)
         readPlan = readPlan?.apply { planStartDate = date } ?: ReadingPlan(planCode, date)
 


### PR DESCRIPTION
I think this fixes https://github.com/AndBible/and-bible/issues/2141

Since `startPlan()` is executed in parallel, if the process is too slow
https://github.com/AndBible/and-bible/blob/051a4751d7e444ce4ef3da04d1ac483a8e03df68/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt#L342
may completes after
https://github.com/AndBible/and-bible/blob/051a4751d7e444ce4ef3da04d1ac483a8e03df68/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt#L345
which causes the failure of "Set as current day".

Actually I don't understand why there is a need to have coroutine in `ReadingPlanRepository`, at least how it is implemented seems to be quite error-prone.