### PR TITLE
fix choose document search #2657

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/base/DocumentSelectionBase.kt
+++ b/app/src/main/java/net/bible/android/view/activity/base/DocumentSelectionBase.kt
@@ -427,11 +427,20 @@ abstract class DocumentSelectionBase(
                         val searchString = "${binding.freeTextSearch.text}*"
                         val osisIds = if(searchString.length < 3) null else dao.search(searchString).toSet()
 
+                        val test = { it: Book ->
+                            // matches from list of osisIds, if any
+                            (osisIds?.contains(it.osisID) ?: (searchString.length < 3)) ||
+                            // partial name match
+                            it.name.contains(binding.freeTextSearch.text,true)
+                            // partial abbreviation  match
+                            it.abbreviation.contains(binding.freeTextSearch.text, true)
+                        }
+
                         for (doc in allDocuments) {
                             val filter = DOCUMENT_TYPE_SPINNER_FILTERS[selectedDocumentFilterNo]
                             if (filter.test(doc) &&
                                 (lang == null || doc.language == lang || doc.bookCategory == BookCategory.AND_BIBLE) &&
-                                (osisIds == null || osisIds.contains(doc.osisID)) &&
+                                test(doc) &&
                                 !doc.isBadDocument(badDocuments.value, BadDocumentAction.HIDE)
                             ) {
                                 displayedDocuments.add(doc)


### PR DESCRIPTION
**Describe the pull request content**
MyBible documents now appear when using search on "Choose document" screen. 

Closes #2657 

**Screenshots**
![Screenshot_20230904-182333](https://github.com/AndBible/and-bible/assets/8870594/8fc8d5a5-1ad2-4ab4-8a86-935cc329b08f)
