### PR TITLE
Use SVG logo in README for nicer GitHub dark theme views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img align="right" width="150" height="150" src="https://user-images.githubusercontent.com/5811789/135705995-ddd550f6-efce-47ef-a3d8-d1ec7ae648fe.png">
+<img align="right" width="250" height="250" src="https://raw.githubusercontent.com/AndBible/and-bible/develop/svg/logo.svg?sanitized=true">
 
 [![Android CI](https://github.com/AndBible/and-bible/workflows/Run%20tests/badge.svg?branch=develop)](https://github.com/AndBible/and-bible/actions/workflows/run-tests.yml)
 [![Licence](https://img.shields.io/badge/licence-GPL-blue.svg)](https://github.com/tuomas2/automate/blob/master/LICENSE.txt)


### PR DESCRIPTION
This is a minor detail, but it has bugged me for a while ever time I open the project on GitHub. GitHub has had an official dark mode for a while, and logos with white backgrounds don't play very nice any more.

This was probably not supported when the logo was first added, but in 2022 they unblocked SVGs as images in Markdown. The PNG could have been made transparent as well, but using the SVG resource already in the repository seems to make the most sense to me. The only caveat is if this README is ever rendered anywhere *off of GitHub* that does not support SVG images. If that's the case then we'd want to post a transparent PNG instead.

Here is a before/after:

![20231013_17h01m50s_grim](https://github.com/AndBible/and-bible/assets/173595/ddfe2788-fde4-45a2-9337-deba4a927d2a)