### PR TITLE
Disable Inline References option when can't be shown

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/OptionsMenuItems.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/OptionsMenuItems.kt
@@ -299,6 +299,10 @@ class RedLettersPreference (settings: SettingsBundle) : Preference(settings, Tex
     override val enabled: Boolean get() = pageManager.isBibleShown && pageManager.currentPage.currentDocument?.hasFeature(FeatureType.WORDS_OF_CHRIST) == true
 }
 
+class ExpandXrefsPreference (settings: SettingsBundle) : Preference(settings, TextDisplaySettings.Types.EXPAND_XREFS) {
+    override val enabled: Boolean get() = Preference(settings, TextDisplaySettings.Types.XREFS).value == true
+}
+
 class StrongsPreference (settings: SettingsBundle) : Preference(settings, TextDisplaySettings.Types.STRONGS) {
     override val enabled: Boolean get() = pageManager.hasStrongs
     override var value get() = if (enabled) super.value else 0

--- a/app/src/main/java/net/bible/android/view/activity/settings/TextDisplaySettings.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/TextDisplaySettings.kt
@@ -46,6 +46,7 @@ import net.bible.android.view.activity.ActivityScope
 import net.bible.android.view.activity.base.ActivityBase
 import net.bible.android.view.activity.page.ColorPreference
 import net.bible.android.view.activity.page.CommandPreference
+import net.bible.android.view.activity.page.ExpandXrefsPreference
 import net.bible.android.view.activity.page.FontFamilyPreference
 import net.bible.android.view.activity.page.FontSizePreference
 import net.bible.android.view.activity.page.HideLabelsPreference
@@ -111,7 +112,7 @@ fun getPrefItem(settings: SettingsBundle, type: Types): OptionsMenuItemInterface
         Types.VERSENUMBERS -> ItemPreference(settings, Types.VERSENUMBERS)
         Types.VERSEPERLINE -> ItemPreference(settings, Types.VERSEPERLINE)
         Types.FOOTNOTES -> ItemPreference(settings, Types.FOOTNOTES)
-        Types.EXPAND_XREFS -> ItemPreference(settings, Types.EXPAND_XREFS)
+        Types.EXPAND_XREFS -> ExpandXrefsPreference(settings)
         Types.XREFS -> ItemPreference(settings, Types.XREFS)
         Types.MYNOTES -> MyNotesPreference(settings)
         Types.STRONGS -> StrongsPreference(settings)


### PR DESCRIPTION
It was a little confusing that I could have Inline Reference enabled but they would not display. This change disables the Inline option if Cross References is not enabled.

![image](https://github.com/AndBible/and-bible/assets/13920678/e5642580-9310-4781-8e6f-ec3bd1c82f55)
