### PR TITLE
Add a Strongs "Hidden links" option

### DIFF
--- a/app/bibleview-js/src/components/OSIS/W.vue
+++ b/app/bibleview-js/src/components/OSIS/W.vue
@@ -101,7 +101,7 @@ function goToLink(event: MouseEvent, url: string) {
         resetHighlights();
         isHighlighted.value = true;
         addCustom(() => isHighlighted.value = false);
-    }, {priority, icon: "custom-morph", title: strings.strongsAndMorph, dottedStrongs: !showStrongsSeparately.value});
+    }, {priority, icon: "custom-morph", title: strings.strongsAndMorph, dottedStrongs: !showStrongsSeparately.value, hiddenStrongs:showStrongsHidden.value});
 }
 
 const exportMode = inject(exportModeKey, ref(false));

--- a/app/bibleview-js/src/components/OSIS/W.vue
+++ b/app/bibleview-js/src/components/OSIS/W.vue
@@ -29,7 +29,8 @@
     <template v-else><slot/></template>
   </template>
   <template v-else>
-    <span v-if="(showStrongs && lemma) || (showStrongs && config.showMorphology && morph)" :class="{isHighlighted}"  class="highlight-transition link-style" @click="goToLink($event, formatLink(lemma, morph))"><slot/></span>
+    <span v-if="(showStrongsHidden && lemma) || (showStrongsHidden && config.showMorphology && morph)" :class="{isHighlighted}"  class="highlight-transition" @click="goToLink($event, formatLink(lemma, morph))"><slot/></span>
+    <span v-else-if="(showStrongs && lemma) || (showStrongs && config.showMorphology && morph)" :class="{isHighlighted}"  class="highlight-transition link-style" @click="goToLink($event, formatLink(lemma, morph))"><slot/></span>
     <span v-else><slot/></span>
   </template>
 </template>
@@ -105,6 +106,7 @@ function goToLink(event: MouseEvent, url: string) {
 
 const exportMode = inject(exportModeKey, ref(false));
 const showStrongs = computed(() => !exportMode.value && config.strongsMode !== strongsModes.off);
+const showStrongsHidden = computed(() => !exportMode.value && config.strongsMode == strongsModes.hidden);
 const showStrongsSeparately = computed(() => !exportMode.value && config.strongsMode === strongsModes.links);
 
 </script>

--- a/app/bibleview-js/src/components/modals/AmbiguousSelection.vue
+++ b/app/bibleview-js/src/components/modals/AmbiguousSelection.vue
@@ -322,12 +322,10 @@ async function handle(event: MouseEvent) {
     if (eventFunctions.length > 0 || _verseInfo != null || _ordinalInfo != null) {
         const firstFunc = eventFunctions[0];
         if (
-            !firstFunc.options.hiddenStrongs && (
-              (eventFunctions.length === 1 && firstFunc.options.priority > 0 && !firstFunc.options.dottedStrongs)
-              || (allEventFunctions.length === 1 && firstFunc.options.dottedStrongs)
-            )
+              (eventFunctions.length === 1 && firstFunc.options.priority > 0 && !firstFunc.options.dottedStrongs && !firstFunc.options.hiddenStrongs)
+              || (allEventFunctions.length === 1 && firstFunc.options.dottedStrongs && !firstFunc.options.hiddenStrongs)
         ) {
-            if (eventFunctions[0].options.bookmarkId) {
+            if (eventFunctions[0].options.bookmarkId || firstFunc.options.hiddenStrongs) {
                 emit("bookmark_clicked", eventFunctions[0].options.bookmarkId, {locateTop: isBottomHalfClicked(event)});
             } else {
                 const cb = eventFunctions[0].callback;

--- a/app/bibleview-js/src/components/modals/AmbiguousSelection.vue
+++ b/app/bibleview-js/src/components/modals/AmbiguousSelection.vue
@@ -322,8 +322,10 @@ async function handle(event: MouseEvent) {
     if (eventFunctions.length > 0 || _verseInfo != null || _ordinalInfo != null) {
         const firstFunc = eventFunctions[0];
         if (
-            (eventFunctions.length === 1 && firstFunc.options.priority > 0 && !firstFunc.options.dottedStrongs)
-            || (allEventFunctions.length === 1 && firstFunc.options.dottedStrongs)
+            !firstFunc.options.hiddenStrongs && (
+              (eventFunctions.length === 1 && firstFunc.options.priority > 0 && !firstFunc.options.dottedStrongs)
+              || (allEventFunctions.length === 1 && firstFunc.options.dottedStrongs)
+            )
         ) {
             if (eventFunctions[0].options.bookmarkId) {
                 emit("bookmark_clicked", eventFunctions[0].options.bookmarkId, {locateTop: isBottomHalfClicked(event)});

--- a/app/bibleview-js/src/composables/config.ts
+++ b/app/bibleview-js/src/composables/config.ts
@@ -22,8 +22,8 @@ import {isEqual} from "lodash";
 import {Deferred} from "@/utils";
 import {BibleViewDocumentType} from "@/types/documents";
 
-export type StrongsMode = 0 | 1 | 2
-export const strongsModes: Record<string, StrongsMode> = {off: 0, inline: 1, links: 2}
+export type StrongsMode = 0 | 1 | 2 | 3
+export const strongsModes: Record<string, StrongsMode> = {off: 0, inline: 1, links: 2, hidden: 3}
 
 export let errorBox = false;
 const white = -1;

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -670,7 +670,7 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
 
             strongsButton.setOnClickListener {
                 val prefOptions = dummyStrongsPrefOption
-                prefOptions.value = (prefOptions.value as Int + 1) % 3
+                prefOptions.value = (prefOptions.value as Int + 1) % 4
                 prefOptions.handle()
                 updateStrongsButton()
             }
@@ -937,16 +937,18 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
                 0 -> binding.strongsButton.setImageResource(R.drawable.ic_strongs_greek)
                 1 -> binding.strongsButton.setImageResource(R.drawable.ic_strongs_greek_links)
                 2 -> binding.strongsButton.setImageResource(R.drawable.ic_strongs_greek_links_text)
+                3 -> binding.strongsButton.setImageResource(R.drawable.ic_strongs_greek)
             }
         } else {
             when (dummyStrongsPrefOption.value) {
                 0 -> binding.strongsButton.setImageResource(R.drawable.ic_strongs_hebrew)
                 1 -> binding.strongsButton.setImageResource(R.drawable.ic_strongs_hebrew_links)
                 2 -> binding.strongsButton.setImageResource(R.drawable.ic_strongs_hebrew_links_text)
+                3 -> binding.strongsButton.setImageResource(R.drawable.ic_strongs_hebrew)
             }
         }
         if(dummyStrongsPrefOption.value == 0) {
-            binding.strongsButton.alpha = 0.7F
+            binding.strongsButton.alpha = 0.5F
         } else
             binding.strongsButton.alpha = 1.0F
     }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -27,6 +27,7 @@
 		<item>@string/strongs_off</item>
 		<item>@string/strongs_links</item>
 		<item>@string/strongs_text_and_links</item>
+		<item>@string/strongs_hidden_links</item>
 	</string-array>
 
 	<string-array name="documentTypes">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1040,6 +1040,7 @@
     <string name="strongs_off">Off</string>
     <string name="strongs_links">Links</string>
     <string name="strongs_text_and_links">Text and Links</string>
+    <string name="strongs_hidden_links">Hidden Links</string>
     <string name="verse_tip">To select partial or many verses, you can long-press Bible text</string>
 
     <string name="permission_required">Permission needed</string>


### PR DESCRIPTION
Something that bothers me is that when I show the Strongs links (without text) I get the dotted underline on almost every word which messes with the bookmarked verse underline and also makes all the text extra busy and not so nice to read.

This PR adds a fourth option to the Strongs Links.
![image](https://github.com/AndBible/and-bible/assets/13920678/8796f657-e7c2-4831-9972-a5ff572d127a)

At present it  functions exactly the same as the "Links" options but without showing the dotted underline.

However I want the single tap option to operate a little differently. It is fine for verses with bookmarks... the verse action dialog is displayed allowing me to add a new bookmark or view the Strongs link. But I want the dialog to **always display** when the links are hidden, even if the verse is not bookmarked. It would essentially work as though their are no links and so show the dialog but **if there is a linked word** it will display 'Definition & Morphology' button.

![image](https://github.com/AndBible/and-bible/assets/13920678/7960e26b-218c-4a24-bfa0-da8f1fd04176)

I can't find the code that does the checking for an existing bookmark. before opening (or not opening) the ambiguous dialog. I think all I need to do is check if we are using Hidden Links and if we are always show the dialog rather than open the Strongs link in the links window.

Could you point me to where this check takes place?
Thanks.