### PR TITLE
Drop use of deprecated buildDir

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,5 +60,6 @@ allprojects {
 }
 
 tasks.register<Delete>("clean") {
-    delete(rootProject.buildDir)
+
+    delete(rootProject.layout.buildDirectory.get().asFile)
 }


### PR DESCRIPTION
**Describe the pull request content**
Drop use of deprecated buildDir
Benefits not using deprecated methods
Possible negative side effects? none

**Screenshots**
N/A
