### PR TITLE
"Find" on selection text: still submit selections greater than 15 chars

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
@@ -528,7 +528,7 @@ class BibleView(val mainBibleActivity: MainBibleActivity,
             if(ref == null && currentSelectionText != null) {
                 val item = menu.findItem(R.id.search)
                 item.isVisible = true
-                item.title = if(currentSelectionText?.length < 16) context.getString(R.string.search_what, currentSelectionText) else context.getString(R.string.search, currentSelectionText)
+                item.title = if(currentSelectionText?.length < 16) context.getString(R.string.search_what, currentSelectionText) else context.getString(R.string.search)
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && currentSelectionText != null) {
                 var menuItemOrder = 100

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
@@ -493,7 +493,7 @@ class BibleView(val mainBibleActivity: MainBibleActivity,
                     setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
                     setVisible(true)
                 }
-                menu.findItem(R.id.add_bookmark_whole_verse).run{
+                menu.Item(R.id.add_bookmark_whole_verse).run{
                     setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
                     setVisible(true)
                 }
@@ -528,7 +528,7 @@ class BibleView(val mainBibleActivity: MainBibleActivity,
             if(ref == null && currentSelectionText != null) {
                 val item = menu.findItem(R.id.search)
                 item.isVisible = true
-                item.title = if(currentSelectionText?.length < 16) context.getString(R.string.search_what, currentSelectionText) else "Find"
+                item.title = if(currentSelectionText?.length < 16) context.getString(R.string.search_what, currentSelectionText) else context.getString(R.string.search, currentSelectionText)
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && currentSelectionText != null) {
                 var menuItemOrder = 100

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
@@ -493,7 +493,7 @@ class BibleView(val mainBibleActivity: MainBibleActivity,
                     setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
                     setVisible(true)
                 }
-                menu.Item(R.id.add_bookmark_whole_verse).run{
+                menu.findItem(R.id.add_bookmark_whole_verse).run{
                     setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
                     setVisible(true)
                 }

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
@@ -525,11 +525,10 @@ class BibleView(val mainBibleActivity: MainBibleActivity,
                     BookName.setFullBookName(wasFullBookName)
                 }
             }
-            val searchText = if(currentSelectionText?.length ?: 0) null else currentSelectionText
-            if(ref == null && searchText != null) {
+            if(ref == null && currentSelectionText != null) {
                 val item = menu.findItem(R.id.search)
                 item.isVisible = true
-                item.title = if(searchText.length < 16) context.getString(R.string.search_what, searchText) else "Find"
+                item.title = if(currentSelectionText?.length < 16) context.getString(R.string.search_what, currentSelectionText) else "Find"
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && currentSelectionText != null) {
                 var menuItemOrder = 100

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
@@ -525,11 +525,11 @@ class BibleView(val mainBibleActivity: MainBibleActivity,
                     BookName.setFullBookName(wasFullBookName)
                 }
             }
-            val searchText = if((currentSelectionText?.length ?: 0) > 15) null else currentSelectionText
+            val searchText = if(currentSelectionText?.length ?: 0) null else currentSelectionText
             if(ref == null && searchText != null) {
                 val item = menu.findItem(R.id.search)
                 item.isVisible = true
-                item.title = context.getString(R.string.search_what, searchText)
+                item.title = if(searchText.length < 16) context.getString(R.string.search_what, searchText) else "Find"
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && currentSelectionText != null) {
                 var menuItemOrder = 100


### PR DESCRIPTION
**Describe the pull request content**
This PR makes it so that the reader can still select text greater than 15 characters in length and send it to the search.
Currently, selections greater than 15 don't generate a "Find" menu option because it always includes the search term in the menu title, and excludes a selection longer than 15.
This is fixed by simply using the shorthand "Find" from the "search" string resource if the selected text is longer than 15 chars.

[NO_TRAIN]::
