### PR TITLE
Remove Multidex usages

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -419,7 +419,6 @@ dependencies {
     // TESTS
     //testImplementation("com.github.AndBible:robolectric:4.3.1-andbible3")
     testImplementation("org.robolectric:robolectric:4.9")
-    //testImplementation("org.robolectric:shadows-multidex:4.3.1")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
     testImplementation("org.hamcrest:hamcrest-library:2.2")
     testImplementation("org.mockito:mockito-core:3.12.4")


### PR DESCRIPTION
**Describe the pull request content**

Since the min SDK is 21/23, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l