### PR TITLE
Improve navigation drawer with header logo/name and footer version

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -195,7 +195,11 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
     private lateinit var mainMenuCommandHandler: MenuCommandHandler
     
     private val navigationView: NavigationView by lazy {
-        binding.drawerLayout.findViewById<NavigationView>(R.id.navigationView)!!
+        binding.drawerLayout.findViewById(R.id.navigationView)!!
+    }
+
+    private val versionTextView: TextView by lazy {
+        binding.drawerLayout.findViewById(R.id.versionText)!!
     }
 
     private var navigationBarHeight = 0
@@ -366,7 +370,6 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
         }
 
         // Set version text in navigation drawer footer
-        val versionTextView = binding.drawerLayout.findViewById<TextView>(R.id.versionText)
         val versionMsg = getString(R.string.version_text, CommonUtils.applicationVersionName)
         versionTextView.text = versionMsg
 

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -360,6 +360,12 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
             mainMenuCommandHandler.handleMenuRequest(menuItem)
         }
 
+        // Set version text in navigation drawer header
+        val headerView = binding.navigationView.getHeaderView(0)
+        val versionTextView = headerView.findViewById<TextView>(R.id.versionText)
+        val versionMsg = getString(R.string.version_text, CommonUtils.applicationVersionName)
+        versionTextView.text = versionMsg
+
         var currentSliderOffset = 0.0F
 
         if (CommonUtils.settings.monochromeMode) {

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -67,6 +67,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.navigation.NavigationView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -192,6 +193,10 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
     lateinit var documentViewManager: DocumentViewManager
     lateinit var bibleViewFactory: BibleViewFactory
     private lateinit var mainMenuCommandHandler: MenuCommandHandler
+    
+    private val navigationView: NavigationView by lazy {
+        binding.drawerLayout.findViewById<NavigationView>(R.id.navigationView)!!
+    }
 
     private var navigationBarHeight = 0
     private var actionBarHeight = 0
@@ -259,7 +264,7 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
             BuildVariant.DistributionChannel.isFdroid ||
             BuildVariant.DistributionChannel.isAmazon
         ) {
-            binding.navigationView.menu.findItem(R.id.rateButton).isVisible = false
+            navigationView.menu.findItem(R.id.rateButton).isVisible = false
         }
 
         CommonUtils.buildActivityComponent().inject(this)
@@ -353,16 +358,15 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
         updateToolbar()
         updateBottomBars()
         if (!CommonUtils.isCloudSyncAvailable) {
-            binding.navigationView.menu.findItem(R.id.googleDriveSync).isVisible = false
+            navigationView.menu.findItem(R.id.googleDriveSync).isVisible = false
         }
-        binding.navigationView.setNavigationItemSelectedListener { menuItem ->
+        navigationView.setNavigationItemSelectedListener { menuItem ->
             binding.drawerLayout.closeDrawers()
             mainMenuCommandHandler.handleMenuRequest(menuItem)
         }
 
-        // Set version text in navigation drawer header
-        val headerView = binding.navigationView.getHeaderView(0)
-        val versionTextView = headerView.findViewById<TextView>(R.id.versionText)
+        // Set version text in navigation drawer footer
+        val versionTextView = binding.drawerLayout.findViewById<TextView>(R.id.versionText)
         val versionMsg = getString(R.string.version_text, CommonUtils.applicationVersionName)
         versionTextView.text = versionMsg
 
@@ -1574,7 +1578,6 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
                 binding.toolbarLayout.setPadding(0, systemInsets.top, 0, 0)
             }
             toolbarLayout.setPadding(leftOffset1, topOffset1, rightOffset1, 0)
-            navigationView.setPadding(leftOffset1, 0, rightOffset1, bottomOffset1)
             speakTransport.setPadding(leftOffset1, 0, rightOffset1, 0)
             
             if(isFullScreen) {

--- a/app/src/main/res/layout/main_bible_view.xml
+++ b/app/src/main/res/layout/main_bible_view.xml
@@ -197,5 +197,6 @@
         android:layout_gravity="start"
         android:fitsSystemWindows="false"
         android:theme="@style/NavigationViewTextStyle"
-        app:menu="@menu/main_bible_drawer_menu" />
+        app:menu="@menu/main_bible_drawer_menu"
+        app:headerLayout="@layout/nav_header_main" />
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/main_bible_view.xml
+++ b/app/src/main/res/layout/main_bible_view.xml
@@ -190,13 +190,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/navigationView"
+    <include layout="@layout/navigation_drawer_with_footer"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        android:fitsSystemWindows="false"
-        android:theme="@style/NavigationViewTextStyle"
-        app:menu="@menu/main_bible_drawer_menu"
-        app:headerLayout="@layout/nav_header_main" />
+        android:fitsSystemWindows="false" />
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
+  ~
+  ~ This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+  ~
+  ~ AndBible is free software: you can redistribute it and/or modify it under the
+  ~ terms of the GNU General Public License as published by the Free Software Foundation,
+  ~ either version 3 of the License, or (at your option) any later version.
+  ~
+  ~ AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with AndBible.
+  ~ If not, see http://www.gnu.org/licenses/.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fitsSystemWindows="true"
+    android:minHeight="100dp"
+    android:layout_marginStart="16dp"
+    android:layout_marginEnd="16dp">
+
+    <!-- Status bar spacer -->
+    <View
+        android:id="@+id/statusBarSpacer"
+        android:layout_width="match_parent"
+        android:layout_height="24dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- App Logo -->
+    <ImageView
+        android:id="@+id/appLogo"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:src="@drawable/ic_logo"
+        android:contentDescription="@string/app_name_andbible"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/statusBarSpacer"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <!-- App Name -->
+    <TextView
+        android:id="@+id/appName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:text="@string/app_name_medium"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:textColor="?attr/android:textColorPrimary"
+        app:layout_constraintTop_toTopOf="@id/appLogo"
+        app:layout_constraintBottom_toBottomOf="@id/appLogo"
+        app:layout_constraintStart_toEndOf="@id/appLogo"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- Version text at bottom -->
+    <TextView
+        android:id="@+id/versionText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/version_text"
+        android:textSize="12sp"
+        android:textColor="?attr/android:textColorSecondary"
+        android:gravity="center"
+        android:layout_marginTop="20dp"
+        app:layout_constraintTop_toBottomOf="@id/appLogo"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout> 

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -41,7 +41,6 @@
         android:layout_height="48dp"
         android:src="@drawable/ic_logo"
         android:contentDescription="@string/app_name_andbible"
-        android:layout_marginTop="16dp"
         app:layout_constraintTop_toBottomOf="@id/statusBarSpacer"
         app:layout_constraintStart_toStartOf="parent" />
 
@@ -59,20 +58,5 @@
         app:layout_constraintBottom_toBottomOf="@id/appLogo"
         app:layout_constraintStart_toEndOf="@id/appLogo"
         app:layout_constraintEnd_toEndOf="parent" />
-
-    <!-- Version text at bottom -->
-    <TextView
-        android:id="@+id/versionText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/version_text"
-        android:textSize="12sp"
-        android:textColor="?attr/android:textColorSecondary"
-        android:gravity="center"
-        android:layout_marginTop="20dp"
-        app:layout_constraintTop_toBottomOf="@id/appLogo"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout> 

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -29,7 +29,7 @@
     <View
         android:id="@+id/statusBarSpacer"
         android:layout_width="match_parent"
-        android:layout_height="24dp"
+        android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/navigation_drawer_with_footer.xml
+++ b/app/src/main/res/layout/navigation_drawer_with_footer.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
+  ~
+  ~ This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+  ~
+  ~ AndBible is free software: you can redistribute it and/or modify it under the
+  ~ terms of the GNU General Public License as published by the Free Software Foundation,
+  ~ either version 3 of the License, or (at your option) any later version.
+  ~
+  ~ AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with AndBible.
+  ~ If not, see http://www.gnu.org/licenses/.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="?attr/android:windowBackground">
+
+    <!-- Navigation View (takes up most of the space) -->
+    <com.google.android.material.navigation.NavigationView
+        android:id="@+id/navigationView"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fitsSystemWindows="false"
+        android:theme="@style/NavigationViewTextStyle"
+        app:menu="@menu/main_bible_drawer_menu"
+        app:headerLayout="@layout/nav_header_main" />
+
+    <!-- Footer with version text -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:background="?attr/android:windowBackground"
+        android:paddingTop="8dp"
+        android:paddingBottom="16dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <!-- Divider line -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?attr/android:listDivider"
+            android:layout_marginBottom="8dp" />
+
+        <!-- Version text -->
+        <TextView
+            android:id="@+id/versionText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/version_text"
+            android:textSize="12sp"
+            android:textColor="?attr/android:textColorSecondary"
+            android:gravity="center"
+            android:padding="8dp" />
+    </LinearLayout>
+
+</LinearLayout> 

--- a/app/src/main/res/menu/main_bible_drawer_menu.xml
+++ b/app/src/main/res/menu/main_bible_drawer_menu.xml
@@ -17,35 +17,30 @@
   -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <item
-        android:title="@string/bible">
-        <menu>
-            <item android:id="@+id/chooseDocumentButton"
-                android:title="@string/chooce_document"
-                android:icon="@drawable/ic_library_books_white_24dp"
-                />
-            <item android:id="@+id/searchButton"
-                android:title="@string/search"
-                android:icon="@drawable/ic_search_24dp"
-                />
-            <item android:id="@+id/speakButton"
-                android:title="@string/speak"
-                android:icon="@drawable/ic_baseline_headphones_24"/>
-            <item android:id="@+id/bookmarksButton"
-                android:title="@string/bookmarks"
-                android:icon="@drawable/ic_baseline_bookmark_24"
-                />
-            <item android:id="@+id/studyPadsButton"
-                android:title="@string/studypads"
-                android:icon="@drawable/ic_baseline_studypads_24"/>
-            <item android:id="@+id/dailyReadingPlanButton"
-                android:title="@string/rdg_plan_title"
-                android:icon="@drawable/ic_reading_plan_24dp"/>
-            <item 	android:id="@+id/historyButton"
-                android:title="@string/history"
-                android:icon="@drawable/ic_history_clock_24dp"/>
-        </menu>
-    </item>
+    <item android:id="@+id/chooseDocumentButton"
+        android:title="@string/chooce_document"
+        android:icon="@drawable/ic_library_books_white_24dp"
+        />
+    <item android:id="@+id/searchButton"
+        android:title="@string/search"
+        android:icon="@drawable/ic_search_24dp"
+        />
+    <item android:id="@+id/speakButton"
+        android:title="@string/speak"
+        android:icon="@drawable/ic_baseline_headphones_24"/>
+    <item android:id="@+id/bookmarksButton"
+        android:title="@string/bookmarks"
+        android:icon="@drawable/ic_baseline_bookmark_24"
+        />
+    <item android:id="@+id/studyPadsButton"
+        android:title="@string/studypads"
+        android:icon="@drawable/ic_baseline_studypads_24"/>
+    <item android:id="@+id/dailyReadingPlanButton"
+        android:title="@string/rdg_plan_title"
+        android:icon="@drawable/ic_reading_plan_24dp"/>
+    <item 	android:id="@+id/historyButton"
+        android:title="@string/history"
+        android:icon="@drawable/ic_history_clock_24dp"/>
     <item
         android:title="@string/administration">
         <menu>


### PR DESCRIPTION
Closes #3420

Any ideas welcome.

### Now (new header top, version at bottom)
<img width="486" height="1023" alt="image" src="https://github.com/user-attachments/assets/1c129ab7-48f5-4a33-bcec-686aa174bd7e" />


### Before
<img width="486" height="1021" alt="image" src="https://github.com/user-attachments/assets/00b167ad-7e33-49a7-b9fc-0609bee4d0f0" />

### Tried this, but don't like it
<img width="486" height="482" alt="image" src="https://github.com/user-attachments/assets/995b8f67-c0b1-4f0d-bb11-4e3c624d660a" />
