### PR TITLE
Bring jsword as a submodule back (?)

### DIFF
--- a/.github/workflows/branch-management.yml
+++ b/.github/workflows/branch-management.yml
@@ -16,6 +16,11 @@ jobs:
       with:
         token: ${{ secrets.TOKEN_CI }}
         fetch-depth: 50
+        submodules: recursive
+    
+    - name: Initialize jsword submodule with shallow clone
+      run: |
+        git submodule update --init --depth=1
 
     - name: Get variables
       id: variables

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -20,6 +20,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 10 # so that recent tags can be found
+        submodules: recursive
+    
+    - name: Initialize jsword submodule with shallow clone
+      run: |
+        git submodule update --init --depth=1
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,6 +27,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 10
+          submodules: recursive
+      
+      - name: Initialize jsword submodule with shallow clone
+        run: |
+          git submodule update --init --depth=1
       
       # Java 17 setup for Android development
       - name: Set up JDK 17

--- a/.github/workflows/jslint.yml
+++ b/.github/workflows/jslint.yml
@@ -31,6 +31,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 10 # so that recent tags can be found
+          submodules: recursive
+      
+      - name: Initialize jsword submodule with shallow clone (if needed for build)
+        run: |
+          git submodule update --init --depth=1
 
       - name: Set up Node.js environment
         uses: actions/setup-node@v3
@@ -55,6 +60,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 10 # so that recent tags can be found
+          submodules: recursive
+      
+      - name: Initialize jsword submodule with shallow clone (if needed for build)
+        run: |
+          git submodule update --init --depth=1
 
       - name: Set up Node.js environment
         uses: actions/setup-node@v3
@@ -87,6 +97,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 10 # so that recent tags can be found
+          submodules: recursive
+      
+      - name: Initialize jsword submodule with shallow clone (if needed for build)
+        run: |
+          git submodule update --init --depth=1
 
       - name: Set up Node.js environment
         uses: actions/setup-node@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 10 # so that recent tags can be found
+        submodules: recursive
+    
+    - name: Initialize jsword submodule with shallow clone
+      run: |
+        git submodule update --init --depth=1
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
@@ -84,6 +89,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 10 # so that recent tags can be found
+        submodules: recursive
+    
+    - name: Initialize jsword submodule with shallow clone
+      run: |
+        git submodule update --init --depth=1
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jsword"]
+	path = jsword
+	url = git@github.com:AndBible/jsword.git

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -363,7 +363,6 @@ androidComponents {
 dependencies {
     val commonsTextVersion: String by rootProject.extra
     val jdomVersion: String by rootProject.extra
-    val jswordVersion: String by rootProject.extra
     val kotlinVersion: String by rootProject.extra
     val coroutinesVersion: String by rootProject.extra
     val kotlinxSerializationVersion: String by rootProject.extra
@@ -430,7 +429,7 @@ dependencies {
     implementation("org.apache.commons:commons-lang3:3.12.0") // make sure this is the same version that commons-text depends on
     implementation("org.apache.commons:commons-text:$commonsTextVersion")
 
-    implementation("com.github.AndBible:jsword:$jswordVersion") {
+    implementation(project(":jsword")) {
         exclude("org.apache.httpcomponents")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ buildscript {
     val jvmToolChainVersion by extra(17)
     val coreKtxVersion by extra("1.16.0")
     val sqliteAndroidVersion by extra("3.49.0")
-    val jswordVersion by extra("2.4.26")
 
 
     repositories {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,4 +15,4 @@
  * If not, see http://www.gnu.org/licenses/.
  */
 
-include(":app")
+include(":app", ":jsword")


### PR DESCRIPTION
I'm not sure if we should use jsword as a submodule still. Let's undo it for now. But leave PR to easily revert again...