### PR TITLE
Implemented a copy button to paste references directly in a better fo…

### DIFF
--- a/app/bibleview-js/src/components/TextEditor.vue
+++ b/app/bibleview-js/src/components/TextEditor.vue
@@ -49,7 +49,7 @@ import {exec, init, queryCommandState} from "@/lib/pell/pell";
 import InputText from "@/components/modals/InputText.vue";
 import {useStrings} from "@/composables/strings";
 import {FontAwesomeIcon} from "@fortawesome/vue-fontawesome";
-import {faBible, faIndent, faListOl, faListUl, faOutdent, faTimes,} from "@fortawesome/free-solid-svg-icons";
+import {faBible, faClipboard, faIndent, faListOl, faListUl, faOutdent, faTimes,} from "@fortawesome/free-solid-svg-icons";
 import {icon} from "@fortawesome/fontawesome-svg-core";
 import {debounce} from "lodash";
 import ModalDialog from "@/components/modals/ModalDialog.vue";
@@ -105,6 +105,44 @@ const close = {
     result: () => {
         save();
         emit('close')
+    }
+}
+
+const pasteReference = {
+    name: 'pasteReference',
+    icon: icon(faClipboard).html,
+    title: 'Paste bible reference from clipboard',
+    result: async () => {
+        if (!android.hasClipboardReference()) {
+            android.toast(strings.noReferenceInClipboard || "No Bible reference in clipboard");
+            return;
+        }
+
+        const clipboardText = android.getClipboardReferenceText();
+        if (!clipboardText) {
+            android.toast(strings.noReferenceInClipboard || "No Bible reference in clipboard");
+            return;
+        }
+
+        const originalRange = document.getSelection()?.getRangeAt(0);
+        let parsed = await android.parseRef(clipboardText);
+        if (parsed === "") {
+            parsed = parse(clipboardText);
+        }
+
+        if (parsed === "") {
+            android.toast(strings.invalidReference);
+            return;
+        }
+
+        if (originalRange) {
+            document.getSelection()!.removeAllRanges();
+            document.getSelection()!.addRange(originalRange);
+        }
+
+        // Insert the reference as a link
+        exec('insertHTML', `<a href="osis://?osis=${parsed}">${clipboardText}</a>`);
+        editor.value!.content.focus();
     }
 }
 
@@ -184,7 +222,7 @@ onMounted(() => {
             dirty.value = true;
         },
         actions: [
-            'bold', 'italic', 'underline', divider, oList, uList, divider, outdent, indent, divider, bibleLink, divider, close
+            'bold', 'italic', 'underline', divider, oList, uList, divider, outdent, indent, divider, pasteReference, bibleLink, divider, close
         ],
     });
     editor.value!.content.innerHTML = editText.value;

--- a/app/bibleview-js/src/components/TextEditor.vue
+++ b/app/bibleview-js/src/components/TextEditor.vue
@@ -108,23 +108,25 @@ const close = {
     }
 }
 
+function escapeHtml(text: string): string {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
 const pasteReference = {
     name: 'pasteReference',
     icon: icon(faClipboard).html,
     title: 'Paste bible reference from clipboard',
     result: async () => {
-        if (!android.hasClipboardReference()) {
-            android.toast(strings.noReferenceInClipboard || "No Bible reference in clipboard");
-            return;
-        }
-
         const clipboardText = android.getClipboardReferenceText();
         if (!clipboardText) {
             android.toast(strings.noReferenceInClipboard || "No Bible reference in clipboard");
             return;
         }
 
-        const originalRange = document.getSelection()?.getRangeAt(0);
+        const selection = document.getSelection();
+        const originalRange = (selection && selection.rangeCount > 0) ? selection.getRangeAt(0) : null;
         let parsed = await android.parseRef(clipboardText);
         if (parsed === "") {
             parsed = parse(clipboardText);
@@ -135,14 +137,13 @@ const pasteReference = {
             return;
         }
 
-        const selection = document.getSelection();
         if (originalRange && selection) {
             selection.removeAllRanges();
             selection.addRange(originalRange);
         }
 
-        // Insert the reference as a link
-        exec('insertHTML', `<a href="osis://?osis=${parsed}">${clipboardText}</a>`);
+        // Insert the reference as a link (escape HTML to prevent XSS)
+        exec('insertHTML', `<a href="osis://?osis=${escapeHtml(parsed)}">${escapeHtml(clipboardText)}</a>`);
         editor.value!.content.focus();
     }
 }

--- a/app/bibleview-js/src/components/TextEditor.vue
+++ b/app/bibleview-js/src/components/TextEditor.vue
@@ -135,9 +135,10 @@ const pasteReference = {
             return;
         }
 
-        if (originalRange) {
-            document.getSelection()!.removeAllRanges();
-            document.getSelection()!.addRange(originalRange);
+        const selection = document.getSelection();
+        if (originalRange && selection) {
+            selection.removeAllRanges();
+            selection.addRange(originalRange);
         }
 
         // Insert the reference as a link

--- a/app/bibleview-js/src/composables/android.ts
+++ b/app/bibleview-js/src/composables/android.ts
@@ -71,6 +71,8 @@ export type BibleJavascriptInterface = {
     shareBookmarkVerse: (bookmarkId: IdType) => void,
     shareVerse: (bookInitials: string, startOrdinal: number, endOrdinal: number) => void,
     copyVerse: (bookInitials: string, startOrdinal: number, endOrdinal: number) => void,
+    hasClipboardReference: () => boolean,
+    getClipboardReferenceText: () => Nullable<string>,
     addBookmark: (bookInitials: string, startOrdinal: number, endOrdinal: number, addNote: boolean) => void,
     addGenericBookmark: (bookInitials: string, osisRef: string, startOrdinal: number, endOrdinal: number, addNote: boolean) => void,
     addParagraphBreakBookmark: (bookInitials: string, startOrdinal: number, endOrdinal: number) => void,
@@ -377,6 +379,14 @@ export function useAndroid({bookmarks}: { bookmarks: Ref<BaseBookmark[]> }, conf
         window.android.copyVerse(bookInitials, startOrdinal, endOrdinal ? endOrdinal : -1);
     }
 
+    function hasClipboardReference(): boolean {
+        return window.android.hasClipboardReference();
+    }
+
+    function getClipboardReferenceText(): Nullable<string> {
+        return window.android.getClipboardReferenceText();
+    }
+
     function addBookmark(bookInitials: string, startOrdinal: number, endOrdinal?: number, addNote: boolean = false) {
         window.android.addBookmark(bookInitials, startOrdinal, endOrdinal ? endOrdinal : -1, addNote);
     }
@@ -579,6 +589,8 @@ export function useAndroid({bookmarks}: { bookmarks: Ref<BaseBookmark[]> }, conf
         refChooserDialog,
         shareVerse,
         copyVerse,
+        hasClipboardReference,
+        getClipboardReferenceText,
         addBookmark,
         addGenericBookmark,
         addParagraphBreakBookmark,
@@ -596,6 +608,8 @@ export function useAndroid({bookmarks}: { bookmarks: Ref<BaseBookmark[]> }, conf
     if (config.developmentMode) return {
         ...stubsFor(exposed, {
             getActiveLanguages: ['he', 'nl', 'en'],
+            hasClipboardReference: false,
+            getClipboardReferenceText: null,
         }),
         querySelection
     } as typeof exposed

--- a/app/bibleview-js/src/declaration.d.ts
+++ b/app/bibleview-js/src/declaration.d.ts
@@ -69,6 +69,7 @@ type TranslatedStrings = {
     inputPlaceholder: string
     inputReference: string
     invalidReference: string
+    noReferenceInClipboard: string
     bookmarkAccurate: string
     bookmarkInaccurate: string
     defaultBook: string

--- a/app/bibleview-js/src/lang/default.yaml
+++ b/app/bibleview-js/src/lang/default.yaml
@@ -21,6 +21,7 @@ editTextPlaceholder: Tap to edit text
 inputPlaceholder: Write here
 inputReference: Enter Bible reference
 invalidReference: Verse not found
+noReferenceInClipboard: No Bible reference in clipboard
 bookmarkAccurate: Bookmark was created in %s
 bookmarkInaccurate: Bookmark book information not stored, content is displayed in %s.
 defaultBook: default Bible document

--- a/app/bibleview-js/src/lang/en.yaml
+++ b/app/bibleview-js/src/lang/en.yaml
@@ -21,6 +21,7 @@ editTextPlaceholder: ""
 inputPlaceholder: ""
 inputReference: ""
 invalidReference: ""
+noReferenceInClipboard: ""
 bookmarkAccurate: Bookmark created in %s
 bookmarkInaccurate: ""
 defaultBook: ""

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
@@ -410,8 +410,8 @@ class BibleJavascriptInterface(
         if (clipData == null || clipData.itemCount == 0) return null
 
         val label = clipData.description.label?.toString() ?: return null
-        // Check if this looks like a Bible reference (matches format like "Gen 1:1" or "John 3:16-17")
-        if (label.isEmpty() || !label.contains(Regex("""\d+:\d+"""))) return null
+        // Check if this looks like a Bible reference (chapter:verse format or single-chapter books)
+        if (label.isEmpty() || !BIBLE_REFERENCE_PATTERN.containsMatchIn(label)) return null
 
         return label
     }
@@ -688,4 +688,11 @@ class BibleJavascriptInterface(
         }
     }
     private val TAG get() = "BibleView[${bibleView.windowRef.get()?.displayId}] JSInt"
+
+    companion object {
+        // Compiled regex for Bible reference detection
+        // Matches either "chapter:verse" (e.g., "Gen 1:1", "John 3:16-17")
+        // or "BookName verse" for single-chapter books (e.g., "Jude 5", "Obadiah 1")
+        private val BIBLE_REFERENCE_PATTERN = Regex("""\d+:\d+|\s\d+""")
+    }
 }

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
@@ -397,6 +397,34 @@ class BibleJavascriptInterface(
     }
 
     @JavascriptInterface
+    fun hasClipboardReference(): Boolean {
+        val clipboardManager = mainBibleActivity.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+        if (!clipboardManager.hasPrimaryClip()) return false
+
+        val clipData = clipboardManager.primaryClip
+        if (clipData == null || clipData.itemCount == 0) return false
+
+        val label = clipData.description.label?.toString() ?: ""
+        // Check if the clipboard contains a Bible reference (label contains verse range name)
+        return label.isNotEmpty() && label.contains(Regex("[0-9]")) // Simple check for verse numbers
+    }
+
+    @JavascriptInterface
+    fun getClipboardReferenceText(): String? {
+        val clipboardManager = mainBibleActivity.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+        if (!clipboardManager.hasPrimaryClip()) return null
+
+        val clipData = clipboardManager.primaryClip
+        if (clipData == null || clipData.itemCount == 0) return null
+
+        val label = clipData.description.label?.toString() ?: return null
+        // Check if this looks like a Bible reference
+        if (label.isEmpty() || !label.contains(Regex("[0-9]"))) return null
+
+        return label
+    }
+
+    @JavascriptInterface
     fun addBookmark(bookInitials: String, startOrdinal: Int, endOrdinal: Int, addNote: Boolean) {
         bibleView.makeBookmark(Selection(bookInitials, startOrdinal, positiveOrNull(endOrdinal)), true, addNote)
     }

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
@@ -398,15 +398,7 @@ class BibleJavascriptInterface(
 
     @JavascriptInterface
     fun hasClipboardReference(): Boolean {
-        val clipboardManager = mainBibleActivity.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-        if (!clipboardManager.hasPrimaryClip()) return false
-
-        val clipData = clipboardManager.primaryClip
-        if (clipData == null || clipData.itemCount == 0) return false
-
-        val label = clipData.description.label?.toString() ?: ""
-        // Check if the clipboard contains a Bible reference (label contains verse range name)
-        return label.isNotEmpty() && label.contains(Regex("[0-9]")) // Simple check for verse numbers
+        return getClipboardReferenceText() != null
     }
 
     @JavascriptInterface
@@ -418,8 +410,8 @@ class BibleJavascriptInterface(
         if (clipData == null || clipData.itemCount == 0) return null
 
         val label = clipData.description.label?.toString() ?: return null
-        // Check if this looks like a Bible reference
-        if (label.isEmpty() || !label.contains(Regex("[0-9]"))) return null
+        // Check if this looks like a Bible reference (matches format like "Gen 1:1" or "John 3:16-17")
+        if (label.isEmpty() || !label.contains(Regex("""\d+:\d+"""))) return null
 
         return label
     }


### PR DESCRIPTION
This addresses #3164. I have added the copy option outside of the bible reference modal for now cause there seems to be now a third icon taking up the initial space suggested in the screenshot. But let me know if theres a better alternative

**Screenshots**
![Photo from Tobe](https://github.com/user-attachments/assets/aafde8f4-1cc3-4968-bef4-b0ca5117828b)

<img width="720" height="1280" alt="Screenshot_20251212-213449" src="https://github.com/user-attachments/assets/06b739a6-29f4-43f1-ab8c-27dd3cf9df06" />


