### PR TITLE
Adjust margin and z-index of menu button in study pads

### DIFF
--- a/app/bibleview-js/src/common.scss
+++ b/app/bibleview-js/src/common.scss
@@ -30,9 +30,9 @@
 
   top: -3px;
   &.isText {
-    top: -15px;
+    top: -12px;
   }
-  z-index: 1;
+  z-index: 11;
 }
 
 .journal-button {


### PR DESCRIPTION
The line used to set the position for new bookmark entries is fine for bookmarks:
<img width="537" height="474" alt="image" src="https://github.com/user-attachments/assets/8aae821d-157c-46ba-8bf8-f32527cf2ecc" />

But for text entries the line sits almost on top of the menu button.
<img width="406" height="507" alt="image" src="https://github.com/user-attachments/assets/8dfcf930-2204-4267-b92e-3828bf6885a0" />

This is a problem because it makes it very hard to use the menu button since the line has a higher z-index.  This PR moves the button down a little which looks nicer and changes its z-index. That might have other consequences. If it does, the z-index can be changed back to 1 and the menu button moved further down - maybe to 10pxs. Any further and it starts to interfere with the text of the entry.