### PR TITLE
Added option to require edit button to edit notes

### DIFF
--- a/app/bibleview-js/src/components/EditableText.vue
+++ b/app/bibleview-js/src/components/EditableText.vue
@@ -52,12 +52,14 @@ const props = withDefaults(defineProps<{
     text: Nullable<string>
     maxEditorHeight?: string
     constraintDisplayHeight?: boolean
+    disableClickToEdit?: boolean
 }>(), {
     editDirectly: false,
     showPlaceholder: false,
     text: null,
     maxEditorHeight: "inherit",
-    constraintDisplayHeight: false
+    constraintDisplayHeight: false,
+    disableClickToEdit: false
 })
 
 const editMode = ref<boolean>(props.editDirectly);
@@ -97,7 +99,7 @@ function textChanged(newText: string) {
 }
 
 function handleClicks(event: MouseEvent) {
-    if ((event.target! as HTMLElement).nodeName !== "A") {
+    if (!props.disableClickToEdit && (event.target! as HTMLElement).nodeName !== "A") {
         editMode.value = true;
     }
 }

--- a/app/bibleview-js/src/components/StudyPadRow.vue
+++ b/app/bibleview-js/src/components/StudyPadRow.vue
@@ -28,7 +28,7 @@
         <div class="journal-button" @click="addNewEntryAfter">
           <FontAwesomeIcon icon="plus-circle"/>
         </div>
-        <div v-if="!journalText" class="journal-button" @click="editMode = true">
+        <div  v-if="!journalText || props.disableClickToEdit" class="journal-button" @click="editMode = true">
           <FontAwesomeIcon icon="edit"/>
         </div>
 
@@ -70,6 +70,7 @@
           :show-placeholder="journalEntry.type === 'journal'"
           :edit-directly="textEntry.new ?? false"
           :text="journalText"
+          :disable-click-to-edit="props.disableClickToEdit"
           @opened="$emit('edit-opened')"
           @save="journalTextChanged"
       />
@@ -99,10 +100,13 @@ import {
 import {AreYouSureButton} from "@/types/common";
 
 const emit = defineEmits(['edit-opened', 'add'])
-const props = defineProps<{
+const props = withDefaults(defineProps<{
     journalEntry: StudyPadItem
-    label: Label
-}>();
+    label: Label,
+    disableClickToEdit?: boolean
+}>(), {
+    disableClickToEdit: true
+});
 
 const bookmarkEntry = computed(() => props.journalEntry as StudyPadBibleBookmarkItem)
 const genericBookmarkEntry = computed(() => props.journalEntry as StudyPadGenericBookmarkItem)

--- a/app/bibleview-js/src/components/documents/StudyPadDocument.vue
+++ b/app/bibleview-js/src/components/documents/StudyPadDocument.vue
@@ -51,12 +51,14 @@
                 @click="moveCursorTo(index)"
             />
             <StudyPadRow
-                :key="`studypad-${j.type}-${j.id}`"
-                :ref="setStudyPadRowRef"
-                :journal-entry="j"
-                :label="document.label"
-                @add="adding=true"
+              :key="`studypad-${j.type}-${j.id}`"
+              :ref="setStudyPadRowRef"
+              :journal-entry="j"
+              :label="document.label"
+              :disable-click-to-edit="appSettings.disableClickToEdit"
+              @add="adding=true"
             />
+
           </div>
         </div>
       </template>

--- a/app/bibleview-js/src/composables/config.ts
+++ b/app/bibleview-js/src/composables/config.ts
@@ -115,6 +115,7 @@ export type AppSettings = {
     disableGenericModalButtons: GenericModalButtonId[],
     monochromeMode: boolean,
     disableAnimations: boolean,
+    disableClickToEdit: boolean,
     fontSizeMultiplier: number,
     enabledExperimentalFeatures: Feature[],
 }
@@ -201,6 +202,7 @@ export function useConfig(documentType: Ref<BibleViewDocumentType>) {
         disableGenericModalButtons: [],
         monochromeMode: false,
         disableAnimations: false,
+        disableClickToEdit: false,
         fontSizeMultiplier: 1.0,
         enabledExperimentalFeatures: [],
     });

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleView.kt
@@ -1384,6 +1384,7 @@ class BibleView(val mainBibleActivity: MainBibleActivity,
         )
         val monochromeMode = CommonUtils.settings.monochromeMode
         val disableAnimations = CommonUtils.settings.disableAnimations
+        val disableClickToEdit = CommonUtils.settings.disableClickToEdit
         val enabledExperimentalFeatures = json.encodeToString(serializer(), CommonUtils.settings.enabledExperimentalFeatures.toList())
         return """
                 bibleView.emit('set_config', {
@@ -1407,6 +1408,7 @@ class BibleView(val mainBibleActivity: MainBibleActivity,
                         disableAnimations: $disableAnimations,
                         fontSizeMultiplier: ${CommonUtils.settings.fontSizeMultiplierFloat},
                         enabledExperimentalFeatures: $enabledExperimentalFeatures,
+                        disableClickToEdit:  $disableClickToEdit,
                     }, 
                     initial: $initial,
                     });

--- a/app/src/main/java/net/bible/android/view/activity/settings/SettingsActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/SettingsActivity.kt
@@ -153,6 +153,7 @@ class SettingsActivity: ActivityBase() {
                     "disable_gen_bookmark_modal_buttons",
                     "monochrome_mode",
                     "disable_animations",
+                    "disable_click_to_edit",
                     "font_size_multiplier",
                     "bible_view_swipe_mode",
                     "experimental_features"

--- a/app/src/main/java/net/bible/service/common/CommonUtils.kt
+++ b/app/src/main/java/net/bible/service/common/CommonUtils.kt
@@ -434,6 +434,7 @@ object CommonUtils : CommonUtilsBase() {
 
         val monochromeMode: Boolean get() = getBoolean("monochrome_mode", onyxSupport?.isMonochrome == true)
         val disableAnimations: Boolean get() = getBoolean("disable_animations", onyxSupport?.isOnyxDevice == true)
+        val disableClickToEdit: Boolean get() = getBoolean("disable_click_to_edit", false)
         val fontSizeMultiplier: Int get() = getInt("font_size_multiplier", 100)
         val fontSizeMultiplierFloat: Float get() = getInt("font_size_multiplier", 100) / 100F
         val bibleViewSwipeMode: BibleViewSwipeMode get() = BibleViewSwipeMode.valueOf(getString("bible_view_swipe_mode", "CHAPTER")!!)

--- a/app/src/main/res/drawable/ic_click_24dp.xml
+++ b/app/src/main/res/drawable/ic_click_24dp.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright (c) 2022 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
+  ~
+  ~ This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+  ~
+  ~ AndBible is free software: you can redistribute it and/or modify it under the
+  ~ terms of the GNU General Public License as published by the Free Software Foundation,
+  ~ either version 3 of the License, or (at your option) any later version.
+  ~
+  ~ AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with AndBible.
+  ~ If not, see http://www.gnu.org/licenses/.
+  -->
+
+<vector android:height="24dp" android:viewportHeight="100"
+    android:viewportWidth="100" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/grey_500"
+        android:pathData="M 23 23 L 23 17 L 31 18 L 31 23 Z M 28 8 L 32 4 L 38 10 L 33 14 Z M 57 18 L 65 17 L 66 23 L 58 23 Z M 51 10 L 56 4 L 61 8 L 55 14 Z M 41 1 L 47 1 L 47 9 L 41 9 Z M 78 43 C 77 43 76 43 75 44 C 74 40 71 38 67 38 C 66 38 65 38 64 38 C 63 35 59 33 56 33 C 55 33 54 33 53 33 L 53 24 C 53 19 49 16 44 16 C 40 16 36 19 36 24 L 36 61 L 33 56 L 33 56 C 29 52 24 51 19 54 C 17 55 16 57 15 60 C 14 63 15 65 17 68 L 31 91 L 31 91 C 35 96 41 100 48 100 L 65 100 C 77 100 86 90 86 78 L 86 52 C 86 47 83 43 78 43 Z M 81 78 C 81 87 74 94 65 94 L 48 94 C 43 94 39 92 36 88 L 21 64 L 21 64 C 21 63 20 62 21 61 C 21 60 22 59 23 58 C 24 57 27 58 28 59 L 42 80 L 42 24 C 42 23 43 21 44 21 C 46 21 47 23 47 24 L 47 53 L 53 53 L 53 41 C 53 40 54 38 56 38 C 57 38 58 40 58 41 L 58 53 L 64 53 L 64 46 C 64 45 65 44 67 44 C 68 44 69 45 69 46 L 69 53 L 75 53 L 75 52 L 75 52 C 75 50 77 49 78 49 C 79 49 81 50 81 52 L 81 78 Z"
+        android:strokeWidth="1"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,9 @@
     <string name="prefs_disable_animations_title">Disable animations</string>
     <string name="prefs_disable_animations_summary">Disable various animations such as smooth scrolling. </string>
 
+    <string name="prefs_disable_click_to_edit_title">Disable Study Pad click-to-edit</string>
+    <string name="prefs_disable_click_to_edit_summary">Requires using the edit button to edit notes in the Study Pad.</string>
+
     <string name="prefs_paragraph_spacing_title">Paragraph spacing (%s mm)</string>
     <string name="prefs_paragraph_spacing_summary">Adjust space between paragraphs.</string>
 

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -123,6 +123,13 @@
             android:defaultValue="false"
             android:icon="@drawable/ic_animate_24dp"
             />
+        <SwitchPreferenceCompat
+            android:key="disable_click_to_edit"
+            android:title="@string/prefs_disable_click_to_edit_title"
+            android:summary="@string/prefs_disable_click_to_edit_summary"
+            android:defaultValue="false"
+            android:icon="@drawable/ic_click_24dp"
+            />
         <SeekBarPreference android:key="font_size_multiplier"
             android:title="@string/pref_font_size_multiplier_title"
             android:summary=""


### PR DESCRIPTION
This PR adds an option allowing the user to disable the click-to-edit study pad entries. The original functionality remains untouched and is default. 

The following changes have been made:
1. A new option in Application Preferences has been added
2. If enabled, study pad entries cannot be edited by simply clicking on one.
3. Rather, the user must choose the Edit button from the menu. This is identical to what is already required if no text entry exists for the bookmark.
4. A new icon for the option has been added
5. New strings for the option has been added.

The issue it addresses is one that has bugged me for a long time... I regularly find myself accidentally going into edit mode when viewing study pad entries. Any click on an existing note will automatically enable the editor and bring up the keyboard. This is particularly frustrating when I am speaking publicly and using a study pad as my sermon notes. As  I speak and scroll i sometimes touch a note which results in me losing half my screen to keyboard and editor. I then have to find the little X to close the window and try again to scroll to where I wanted to go.
