### PR TITLE
Jump to verse 0 when changing chapters (works but has issues)

### DIFF
--- a/app/src/main/java/net/bible/android/control/page/CurrentBiblePage.kt
+++ b/app/src/main/java/net/bible/android/control/page/CurrentBiblePage.kt
@@ -107,7 +107,14 @@ class CurrentBiblePage(
                     nextVer = bibleTraverser.getPrevChapter(currentPassageBook, nextVer)
                 }
             }
-            nextVer
+            // Needed for swiping left or right
+            if (nextVer.verse == 1) {
+                Verse(nextVer.versification,nextVer.book,nextVer.chapter,0
+                )
+            } else {
+                nextVer
+            }
+
         } catch (nsve: Exception) {
             Log.e(TAG, "Incorrect verse", nsve)
             currVer

--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
@@ -259,7 +259,7 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
                     // select verse (only 1 chapter)
                     val myIntent = Intent(this, GridChoosePassageVerse::class.java)
                     myIntent.putExtra(GridChoosePassageBook.BOOK_NO, bibleBookNo)
-                    myIntent.putExtra(GridChoosePassageBook.CHAPTER_NO, 0)
+                    myIntent.putExtra(GridChoosePassageBook.CHAPTER_NO, 1)
                     myIntent.putExtra("navigateToVerse", navigateToVerse)
                     startActivityForResult(myIntent, 1)
                 }

--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageBook.kt
@@ -248,7 +248,7 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
             // if there is only 1 chapter then no need to select chapter, but may need to select verse still
             if (!navigationControl.hasChapters(book)) {
                 if (!navigateToVerse) {
-                    val verse = Verse(v11n, book, 1, 1)
+                    val verse = Verse(v11n, book, 1, 0)
 
                     val resultIntent = Intent(this, GridChoosePassageBook::class.java)
                     resultIntent.putExtra("verse", verse.osisID)
@@ -259,7 +259,7 @@ class GridChoosePassageBook : CustomTitlebarActivityBase(R.menu.choose_passage_b
                     // select verse (only 1 chapter)
                     val myIntent = Intent(this, GridChoosePassageVerse::class.java)
                     myIntent.putExtra(GridChoosePassageBook.BOOK_NO, bibleBookNo)
-                    myIntent.putExtra(GridChoosePassageBook.CHAPTER_NO, 1)
+                    myIntent.putExtra(GridChoosePassageBook.CHAPTER_NO, 0)
                     myIntent.putExtra("navigateToVerse", navigateToVerse)
                     startActivityForResult(myIntent, 1)
                 }

--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageChapter.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageChapter.kt
@@ -130,13 +130,11 @@ class GridChoosePassageChapter : CustomTitlebarActivityBase(), OnButtonGridActio
         try {
             val currentPageControl = windowControl.activeWindowPageManager
             if (!navigateToVerse && !currentPageControl.currentPage.isSingleKey) {
-                val verse = Verse(navigationControl.versification, mBibleBook, chapter, 1)
+                val verse = Verse(navigationControl.versification, mBibleBook, chapter, 0)
                 val resultIntent = Intent(this, GridChoosePassageBook::class.java)
                 resultIntent.putExtra("verse", verse.osisID)
                 setResult(Activity.RESULT_OK, resultIntent)
                 finish()
-
-
                 onSave(null)
             } else {
                 // select verse

--- a/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageVerse.kt
+++ b/app/src/main/java/net/bible/android/view/activity/navigation/GridChoosePassageVerse.kt
@@ -120,7 +120,9 @@ class GridChoosePassageVerse : CustomTitlebarActivityBase(), OnButtonGridActionL
     }
 
     override fun buttonPressed(buttonInfo: ButtonInfo) {
-        val verse = Verse(navigationControl.versification, mBibleBook, mBibleChapterNo, buttonInfo.id)
+        val verseNo = if (buttonInfo.id!=1) buttonInfo.id else 0
+        val verse = Verse(navigationControl.versification, mBibleBook, mBibleChapterNo, verseNo)
+
         Log.i(TAG, "Verse selected:$verse")
         val resultIntent = Intent(this, GridChoosePassageBook::class.java)
         resultIntent.putExtra("verse", verse.osisID)


### PR DESCRIPTION
There are significant issues with this code when moving to a chapter that is already displayed or almost displayed on screen. Maybe the issue is easily fixed but I couldn't see how.

What I want to see when I choose verse 1 is the chapter heading and any heading text telling me what the chapter is about.
<img width="396" height="319" alt="image" src="https://github.com/user-attachments/assets/193532d6-e511-4f8a-9da0-930bb02c9216" />

This PR does that nicely when selecting a bible verse from the verse chooser as long as the selected chapter is not already on the screen. For a phone this is not often a problem but when the text gets small or the chapters get small, the screen does not scroll the text to the top of the screen like it should.

<img width="396" alt="image" src="https://github.com/user-attachments/assets/545444d4-ecbf-4619-abfe-9503bbbcede1" />

This is most noticeable when swiping left or right unfortunately. Sadly this is where i most want to use it - I know roughly where a verse is located so i go to a chapter before that and just swipe right until i find the chapter heading that i want. At present one needs to swipe, scroll up to see what the chapter title is, swipe and repeat.

I stumbled onto this comment in   java/net/bible/android/view/activity/page/BibleView.kt

    companion object {
        // never go to 0 because a bug in Android prevents invalidate after loadDataWithBaseURL so
        // no scrollOrJumpToVerse will occur
        private const val TOP_OF_SCREEN = 1
    }

"no scrollOrJumpToVerse will occur" is exactly what I see but only when the chapter i want to jump to is on screen or almost on screen.

If anyone has some suggestions on how to fix this I am happy to try.