### PR TITLE
Fix TTS engine selection on Samsung devices

### DIFF
--- a/app/src/main/java/net/bible/service/device/speak/TextToSpeechServiceManager.kt
+++ b/app/src/main/java/net/bible/service/device/speak/TextToSpeechServiceManager.kt
@@ -22,6 +22,7 @@ import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.os.Build
+import android.provider.Settings
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import android.util.Log
@@ -86,6 +87,7 @@ class TextToSpeechServiceManager @Inject constructor(
 ) {
 
     private var mTts: TextToSpeech? = null
+    private var configuredEnginePackage: String? = null
 
     private var localePreferenceList: MutableList<Locale> = ArrayList()
     private var currentLocale: Locale = Locale.getDefault()
@@ -366,23 +368,49 @@ class TextToSpeechServiceManager @Inject constructor(
     }
 
     private fun initializeTtsOrStartSpeaking() {
+        val preferredEnginePackage = getPreferredTtsEnginePackage()
         if (mTts == null) {
             Log.i(TAG, "mTts was null so initialising Tts")
-
-            try {
-                // Initialize text-to-speech. This is an asynchronous operation.
-                // The OnInitListener (second argument) (this class) is called after initialization completes.
-                mTts = TextToSpeech(application.applicationContext, this.onInitListener)
-                if(application.isRunningTests) {
-                    this.onInitListener.onInit(TextToSpeech.SUCCESS)
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Error initialising Tts", e)
-                showError(R.string.error_occurred, e)
-            }
-
+            initializeTts(preferredEnginePackage)
+        } else if (preferredEnginePackage != configuredEnginePackage) {
+            Log.i(
+                TAG,
+                "TTS engine preference changed from '$configuredEnginePackage' to '$preferredEnginePackage', reinitialising"
+            )
+            shutdownTtsEngine()
+            initializeTts(preferredEnginePackage)
         } else {
             startSpeaking()
+        }
+    }
+
+    private fun initializeTts(preferredEnginePackage: String?) {
+        try {
+            // Initialize text-to-speech. This is an asynchronous operation.
+            // The OnInitListener (second argument) (this class) is called after initialization completes.
+            mTts = if (preferredEnginePackage != null) {
+                TextToSpeech(application.applicationContext, this.onInitListener, preferredEnginePackage)
+            } else {
+                TextToSpeech(application.applicationContext, this.onInitListener)
+            }
+            configuredEnginePackage = preferredEnginePackage
+            if (application.isRunningTests) {
+                this.onInitListener.onInit(TextToSpeech.SUCCESS)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error initialising Tts", e)
+            showError(R.string.error_occurred, e)
+        }
+    }
+
+    private fun getPreferredTtsEnginePackage(): String? {
+        return try {
+            Settings.Secure.getString(application.contentResolver, Settings.Secure.TTS_DEFAULT_SYNTH)
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to read preferred TTS engine from system settings", e)
+            null
         }
     }
 
@@ -610,6 +638,7 @@ class TextToSpeechServiceManager @Inject constructor(
             Log.e(TAG, "Error shutting down Tts engine", e)
         } finally {
             mTts = null
+            configuredEnginePackage = null
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
## What changed
- Read preferred TTS engine package from Android system setting (`Settings.Secure.TTS_DEFAULT_SYNTH`).
- Initialize `TextToSpeech` with that preferred engine package when available.
- Re-initialize TTS if engine preference changes while app process is still alive.

## Benefits
- AndBible now follows the same selected TTS engine as device system settings more reliably.
- Fixes cases where app stayed on Google TTS even after switching to Samsung TTS.

## Possible side effects
- If a device reports an invalid engine package in system settings, TTS initialization can fail (existing error handling remains in place).
- Re-initialization happens when engine preference changes, which may briefly interrupt active speech.

Fixes #3567