### PR TITLE
Fix TTS chapter switch after manual navigation

### DIFF
--- a/app/src/main/java/net/bible/android/control/speak/SpeakControl.kt
+++ b/app/src/main/java/net/bible/android/control/speak/SpeakControl.kt
@@ -149,14 +149,58 @@ class SpeakControl @Inject constructor(
 
     private var speakBook: Book? = null
     private var speakKey: Key? = null
+    private var lastFollowedSpeakKey: Key? = null
+    private var speakAutoFollowEnabled = true
     val speakBookAndKey: BookAndKey? get() = speakKey?.let {BookAndKey(it, speakBook) }
 
     fun onEventMainThread(event: SpeakProgressEvent) {
         speakKey = event.key
         speakBook = event.book
         if (AdvancedSpeakSettings.synchronize || event.forceFollow) {
+            if (AdvancedSpeakSettings.synchronize && !event.forceFollow) {
+                val movedAwayFromSpeak = movedAwayFromFollowedSpeakKey()
+                if (speakAutoFollowEnabled && movedAwayFromSpeak) {
+                    if (restartSpeakFromCurrentSelection()) {
+                        return
+                    } else {
+                        Log.i(TAG, "Suspend speak auto-follow because user moved away from active speak location")
+                        speakAutoFollowEnabled = false
+                    }
+                } else if (!speakAutoFollowEnabled && !movedAwayFromSpeak) {
+                    Log.i(TAG, "Resume speak auto-follow after returning to active speak location")
+                    speakAutoFollowEnabled = true
+                }
+
+                if (!speakAutoFollowEnabled) {
+                    return
+                }
+            }
             val book = speakPageManager.currentPage.currentDocument
             speakPageManager.setCurrentDocumentAndKey(book, event.key,false)
+            lastFollowedSpeakKey = event.key
+        }
+    }
+
+    private fun restartSpeakFromCurrentSelection(): Boolean {
+        if (!isSpeaking && !isPaused) return false
+
+        val page = speakPageManager.currentPage
+        val bibleBook = page.currentDocument as? SwordBook ?: return false
+        val verse = page.singleKey as? Verse ?: return false
+
+        Log.i(TAG, "Restart speak from manually selected verse at boundary: ${verse.osisRef}")
+        speakBible(bibleBook, verse, force = true)
+        return true
+    }
+
+    private fun movedAwayFromFollowedSpeakKey(): Boolean {
+        val previousSpeakKey = lastFollowedSpeakKey ?: return false
+        val currentPageKey = speakPageManager.currentPage.key ?: return false
+        return try {
+            !currentPageKey.contains(previousSpeakKey)
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to compare current key with previous speak key", e)
+            false
         }
     }
 
@@ -287,6 +331,7 @@ class SpeakControl @Inject constructor(
         prepareForSpeaking()
         if(AdvancedSpeakSettings.synchronize || force) {
             speakPageManager.setCurrentDocumentAndKey(book, verse,false)
+            lastFollowedSpeakKey = verse
         }
         try {
             ttsServiceManager.speakBible(book, verse)
@@ -453,6 +498,8 @@ class SpeakControl @Inject constructor(
     }
 
     private fun prepareForSpeaking() {
+        speakAutoFollowEnabled = true
+        lastFollowedSpeakKey = null
         if(CommonUtils.isDiscrete) {
             GlobalScope.launch {
                 CommonUtils.requestNotificationPermission()

--- a/app/src/main/java/net/bible/android/control/speak/SpeakControl.kt
+++ b/app/src/main/java/net/bible/android/control/speak/SpeakControl.kt
@@ -189,6 +189,8 @@ class SpeakControl @Inject constructor(
         val verse = page.singleKey as? Verse ?: return false
 
         Log.i(TAG, "Restart speak from manually selected verse at boundary: ${verse.osisRef}")
+        // This intentionally resets follow-tracking state via prepareForSpeaking().
+        // After a manual jump, auto-follow should restart from the new user-selected verse.
         speakBible(bibleBook, verse, force = true)
         return true
     }
@@ -197,7 +199,12 @@ class SpeakControl @Inject constructor(
         val previousSpeakKey = lastFollowedSpeakKey ?: return false
         val currentPageKey = speakPageManager.currentPage.key ?: return false
         return try {
-            !currentPageKey.contains(previousSpeakKey)
+            // Keys can be Verse or VerseRange depending on event/page context.
+            // Treat either-direction containment as "still on followed location" and only
+            // suspend auto-follow when there is no overlap in either direction.
+            val stillOnFollowedLocation =
+                currentPageKey.contains(previousSpeakKey) || previousSpeakKey.contains(currentPageKey)
+            !stillOnFollowedLocation
         } catch (e: Exception) {
             Log.w(TAG, "Unable to compare current key with previous speak key", e)
             false

--- a/app/src/test/java/net/bible/service/device/speak/SpeakTests.kt
+++ b/app/src/test/java/net/bible/service/device/speak/SpeakTests.kt
@@ -42,6 +42,7 @@ import net.bible.service.common.CommonUtils
 import net.bible.android.database.bookmarks.BookmarkEntities.BibleBookmarkWithNotes
 import net.bible.android.database.bookmarks.BookmarkEntities.Label
 import net.bible.service.common.AdvancedSpeakSettings
+import net.bible.service.device.speak.event.SpeakProgressEvent
 import net.bible.service.sword.SwordContentFacade
 import net.bible.test.DatabaseResetter
 import org.crosswire.jsword.book.Books
@@ -224,6 +225,39 @@ class SpeakIntegrationTests : SpeakIntegrationTestBase() {
         changeSpeed(204)
         b = bookmarkControl.bibleBookmarkStartingAtVerse((getVerse("Rom.1.5")))[0]
         assertThat(b!!.playbackSettings!!.speed, equalTo(203))
+    }
+
+    @Test
+    fun testSpeakFollowDoesNotJumpBackAfterManualChapterChange() {
+        val acts11 = getVerse("Acts.1.1")
+        val acts12 = getVerse("Acts.1.2")
+        val acts13 = getVerse("Acts.1.3")
+        val rom11 = getVerse("Rom.1.1")
+
+        speakControl.speakBible(book, acts11)
+        speakControl.onEventMainThread(SpeakProgressEvent(book, VerseRange(book.versification, acts11, acts12), null))
+
+        windowControl.activeWindowPageManager.setCurrentDocumentAndKey(book, rom11)
+        speakControl.onEventMainThread(SpeakProgressEvent(book, VerseRange(book.versification, acts13, acts13), null))
+
+        val currentVerse = windowControl.activeWindowPageManager.currentBible.singleKey
+        assertThat(currentVerse.osisRef, equalTo(rom11.osisRef))
+        speakControl.pause()
+        assertThat(CommonUtils.settings.getString("lastSpeakRef"), equalTo(rom11.osisRef))
+    }
+
+    @Test
+    fun testSpeakFollowStillMovesToNextChapterWhenUserHasNotMovedAway() {
+        val rom131 = getVerse("Rom.1.31")
+        val rom132 = getVerse("Rom.1.32")
+        val rom21 = getVerse("Rom.2.1")
+
+        speakControl.speakBible(book, rom131)
+        speakControl.onEventMainThread(SpeakProgressEvent(book, VerseRange(book.versification, rom131, rom132), null))
+        speakControl.onEventMainThread(SpeakProgressEvent(book, VerseRange(book.versification, rom21, rom21), null))
+
+        val currentVerse = windowControl.activeWindowPageManager.currentBible.singleKey
+        assertThat(currentVerse.osisRef, equalTo(rom21.osisRef))
     }
 }
 

--- a/app/src/test/java/net/bible/service/device/speak/SpeakTests.kt
+++ b/app/src/test/java/net/bible/service/device/speak/SpeakTests.kt
@@ -235,6 +235,7 @@ class SpeakIntegrationTests : SpeakIntegrationTestBase() {
         val rom11 = getVerse("Rom.1.1")
 
         speakControl.speakBible(book, acts11)
+        assertThat(speakControl.isSpeaking || speakControl.isPaused, equalTo(true))
         speakControl.onEventMainThread(SpeakProgressEvent(book, VerseRange(book.versification, acts11, acts12), null))
 
         windowControl.activeWindowPageManager.setCurrentDocumentAndKey(book, rom11)


### PR DESCRIPTION
## What changed
- Updated `SpeakControl` follow logic for synchronized TTS progress events.
- When user manually changes chapter/book while TTS is speaking, next utterance boundary now restarts TTS from the currently selected verse.
- Preserved normal auto-follow behavior when user has not moved away.
- Added integration test coverage for:
  - manual chapter switch during speaking
  - normal boundary progression without manual navigation

## Benefits
- Fixes stale speech continuation after manual chapter switch.
- Keeps spoken content aligned with visible selection.
- Prevents regressions with explicit tests.

## Possible side effects
- At boundary after manual navigation, ongoing TTS queue is restarted from current selection (expected behavior change).

## Validation
- `./gradlew :app:assembleStandardGithubDebug -x jsBuild --no-daemon`
- Manual validation on Samsung A22 (`SM-A226B`):
  - Reproduced previous issue path (Acts -> Romans while TTS running)
  - Verified no jump-back and TTS resumes from selected chapter