### PR TITLE
Fix MyBible red letter rendering (#2132)

### DIFF
--- a/app/bibleview-js/src/__tests__/osis.spec.js
+++ b/app/bibleview-js/src/__tests__/osis.spec.js
@@ -73,10 +73,46 @@ function verifyXmlRendering(xmlTemplate, renderedHtml) {
     expect(wrapper.html() + "\n").toBe(renderedHtml);
 }
 
+function mountOsisSegment(xmlTemplate, {showRedLetters = false} = {}) {
+    const {config, appSettings, calculatedConfig} = useConfig(ref("bible"));
+    config.showRedLetters = showRedLetters;
+
+    const osisFragment = {
+        bookCategory: "BIBLE",
+    };
+
+    const android = useAndroid({bookmarks: null}, config);
+    const provide = {
+        [osisFragmentKey]: osisFragment,
+        [configKey]: config,
+        [appSettingsKey]: appSettings,
+        [calculatedConfigKey]: calculatedConfig,
+        [footnoteCountKey]: {getFootNoteCount: () => 0},
+        [androidKey]: android,
+        [stringsKey]: useStrings(),
+        [ordinalHighlightKey]: useOrdinalHighlight(),
+        [globalBookmarksKey]: useGlobalBookmarks(config),
+        [modalKey]: useModal(android),
+    };
+    const components = {AmbiguousSelection, LabelList, BookmarkLabelActions};
+    return mount(OsisSegment, {props: {osisTemplate: xmlTemplate, convert: true}, global: {provide, components}});
+}
+
 describe("OsisSegment.vue", () => {
     // Skipping this now. Need to figure out how to make sure scoped css do not break our test
     // This does not seem to work, for some reason
     // https://runthatline.com/test-css-module-classes-in-vue-with-vitest/
     // https://github.com/AndBible/and-bible/issues/2434
     it.skip("Test rendering of Eph 2:8 in KJVA, #1985", () => verifyXmlRendering(test1Xml, test1Result));
+
+    it("renders MyBible J tags as red letters when enabled", () => {
+        const wrapper = mountOsisSegment("<J>Jesus words</J>", {showRedLetters: true});
+        expect(wrapper.find(".redLetters").exists()).toBe(true);
+        expect(wrapper.find(".redLetters").text()).toBe("Jesus words");
+    });
+
+    it("does not add red letter class when disabled", () => {
+        const wrapper = mountOsisSegment("<J>Jesus words</J>", {showRedLetters: false});
+        expect(wrapper.find(".redLetters").exists()).toBe(false);
+    });
 });

--- a/app/bibleview-js/src/components/MyBible/J.vue
+++ b/app/bibleview-js/src/components/MyBible/J.vue
@@ -1,0 +1,31 @@
+<!--
+  - Copyright (c) 2022-2022 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
+  -
+  - This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+  -
+  - AndBible is free software: you can redistribute it and/or modify it under the
+  - terms of the GNU General Public License as published by the Free Software Foundation,
+  - either version 3 of the License, or (at your option) any later version.
+  -
+  - AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  - without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  - See the GNU General Public License for more details.
+  -
+  - You should have received a copy of the GNU General Public License along with AndBible.
+  - If not, see http://www.gnu.org/licenses/.
+  -->
+
+<template>
+  <Q who="jesus"><slot/></Q>
+</template>
+
+<script setup lang="ts">
+import Q from "@/components/OSIS/Q.vue";
+import {useCommon} from "@/composables";
+
+useCommon();
+</script>
+
+<style lang="scss">
+@use "@/common.scss" as *;
+</style>

--- a/app/bibleview-js/src/components/documents/OsisSegment.vue
+++ b/app/bibleview-js/src/components/documents/OsisSegment.vue
@@ -51,6 +51,7 @@ import NoOp from "@/components/OSIS/NoOp.vue";
 import H3 from "@/components/MyBible/H3.vue";
 import I from "@/components/MyBible/I.vue";
 import S from "@/components/MyBible/S.vue";
+import J from "@/components/MyBible/J.vue";
 import B from "@/components/MyBible/B.vue";
 import Br from "@/components/MyBible/Br.vue";
 import Li from "@/components/MyBible/Li.vue";
@@ -71,7 +72,7 @@ const andBibleComponents = {
 }
 
 const myBibleComponents = {
-    S, M: NoOp, I, J: Q, N: Note, Pb, F: NoOp, H: Title, E: Hi, H3, B, Br, Li, Ol, Strong,
+    S, M: NoOp, I, J, N: Note, Pb, F: NoOp, H: Title, E: Hi, H3, B, Br, Li, Ol, Strong,
 }
 
 const osisComponents = {
@@ -119,4 +120,3 @@ export default defineComponent({
     },
 })
 </script>
-

--- a/app/src/main/java/net/bible/service/sword/mybible/MyBibleBook.kt
+++ b/app/src/main/java/net/bible/service/sword/mybible/MyBibleBook.kt
@@ -51,6 +51,7 @@ fun getConfig(
     category: String,
     hasStrongsDef: Boolean = false,
     hasStrongs: Boolean = false,
+    hasWordsOfChrist: Boolean = false,
     moduleFileName: String,
     downloadUrl: String = "",
 ): String {
@@ -77,6 +78,9 @@ Versification=KJVA"""
     if(hasStrongs) {
         conf += "\nGlobalOptionFilter = OSISStrongs"
     }
+    if(hasWordsOfChrist) {
+        conf += "\nFeature=WordsOfChrist"
+    }
     return conf
 }
 
@@ -84,6 +88,8 @@ const val TAG = "MyBibleBook"
 
 private val re = Regex("[^a-zA-z0-9]")
 fun sanitizeModuleName(name: String): String = name.replace(re, "_")
+private fun parseMyBibleBoolean(value: String?): Boolean =
+    value.equals("true", ignoreCase = true) || value == "1"
 
 class SqliteVerseBackendState(private val sqliteFile: File): OpenFileState {
     constructor(sqliteFile: File, metadata: SwordBookMetaData): this(sqliteFile) {
@@ -148,6 +154,30 @@ class SqliteVerseBackendState(private val sqliteFile: File): OpenFileState {
             val isBible = tables.contains("verses")
             val isDictionary = tables.contains("dictionary")
             hasStories = tables.contains("stories")
+            val hasWordsOfChrist = if (isBible) {
+                try {
+                    val hasInfoFlag = db.rawQuery(
+                        "select value from info where name in ('is_words_of_christ', 'words_of_christ', 'is_red_letter', 'red_letter')",
+                        null
+                    ).use { cur ->
+                        while (cur.moveToNext()) {
+                            if (parseMyBibleBoolean(cur.getString(0))) {
+                                return@use true
+                            }
+                        }
+                        false
+                    }
+                    hasInfoFlag || db.rawQuery(
+                        "select 1 from verses where instr(lower(text), '<j>') > 0 limit 1",
+                        null
+                    ).use { it.moveToFirst() }
+                } catch (e: SQLiteException) {
+                    Log.w(TAG, "Failed to detect WordsOfChrist support for ${db.path}", e)
+                    false
+                }
+            } else {
+                false
+            }
 
             val category = when {
                 isBible -> "Biblical Texts"
@@ -164,6 +194,7 @@ class SqliteVerseBackendState(private val sqliteFile: File): OpenFileState {
                 category = category,
                 hasStrongsDef = hasStrongsDef,
                 hasStrongs = hasStrongs,
+                hasWordsOfChrist = hasWordsOfChrist,
                 moduleFileName = db.path!!,
             )
             Log.i(TAG, "Creating MyBibleBook metadata $initials, $description $language $category")

--- a/app/src/test/java/net/bible/service/sword/mybible/MyBibleBookTest.kt
+++ b/app/src/test/java/net/bible/service/sword/mybible/MyBibleBookTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026-2026 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
+ *
+ * This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+ *
+ * AndBible is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with AndBible.
+ * If not, see http://www.gnu.org/licenses/.
+ */
+
+package net.bible.service.sword.mybible
+
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class MyBibleBookTest {
+
+    @Test
+    fun `getConfig should include WordsOfChrist feature when requested`() {
+        val config = getConfig(
+            initials = "MyBible-Test",
+            abbreviation = "Test",
+            description = "Test",
+            language = "en",
+            category = "Biblical Texts",
+            hasWordsOfChrist = true,
+            moduleFileName = "/tmp/module.SQLite3"
+        )
+
+        assertThat(config, containsString("Feature=WordsOfChrist"))
+    }
+
+    @Test
+    fun `getConfig should not include WordsOfChrist feature by default`() {
+        val config = getConfig(
+            initials = "MyBible-Test",
+            abbreviation = "Test",
+            description = "Test",
+            language = "en",
+            category = "Biblical Texts",
+            moduleFileName = "/tmp/module.SQLite3"
+        )
+
+        assertThat(config, not(containsString("Feature=WordsOfChrist")))
+    }
+}


### PR DESCRIPTION
## What changed
- Added MyBible red-letter feature detection in `MyBibleBook.kt`:
  - reads known info flags if present
  - falls back to detecting `<J>...</J>` markup in `verses` text
  - enables `Feature=WordsOfChrist` in generated module config when supported
- Added `app/bibleview-js/src/components/MyBible/J.vue` to render MyBible `<J>` tags through OSIS quote component with `who="jesus"`.
- Updated `OsisSegment.vue` MyBible component map to use the new `J` component.
- Added regression tests:
  - JS: MyBible `<J>` is red when `showRedLetters=true` and not red when disabled
  - Kotlin: `getConfig()` includes `Feature=WordsOfChrist` only when requested

## Benefits
- MyBible modules can now expose and render words of Jesus in red similarly to other supported modules.
- Red letters respect existing app setting (`showRedLetters`) and stay off when disabled.

## Possible side effects
- Metadata initialization for MyBible Bible modules now performs one additional lightweight lookup for `<J>` tags in `verses`.
- Modules that use non-standard red-letter markup (without `<J>` and without info flags) will still not be auto-detected.

Fixes #2132.
