### PR TITLE
Allow use of unicode superscript verse numbers. Fixes: #3686

### DIFF
--- a/app/src/main/java/net/bible/android/view/util/widget/ShareWidget.kt
+++ b/app/src/main/java/net/bible/android/view/util/widget/ShareWidget.kt
@@ -54,6 +54,7 @@ class ShareWidget(context: Context, attributeSet: AttributeSet?, val selection: 
 
             // apply isChecked to toggles based on settings
             toggleVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_verse_numbers", true)
+            toggleSuperscriptVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_superscript_verse_numbers", false)
             advertise.isChecked = CommonUtils.settings.getBoolean("share_show_add", true)
             toggleShowReference.isChecked = CommonUtils.settings.getBoolean("share_show_reference", true)
             toggleAbbreviateReference.isChecked = CommonUtils.settings.getBoolean("share_abbreviate_reference", true)
@@ -69,6 +70,7 @@ class ShareWidget(context: Context, attributeSet: AttributeSet?, val selection: 
 
             // update text when any toggle is clicked
             toggleVersenumbers.setOnClickListener { updateWidgetState() }
+            toggleSuperscriptVersenumbers.setOnClickListener { updateWidgetState() }
             advertise.setOnClickListener { updateWidgetState() }
             toggleShowReference.setOnClickListener { updateWidgetState() }
             toggleAbbreviateReference.setOnClickListener { updateWidgetState() }
@@ -105,6 +107,7 @@ class ShareWidget(context: Context, attributeSet: AttributeSet?, val selection: 
         // update widget share option settings
         CommonUtils.settings.apply {
             setBoolean("share_verse_numbers", bindings.toggleVersenumbers.isChecked)
+            setBoolean("share_superscript_verse_numbers", bindings.toggleSuperscriptVersenumbers.isChecked)
             setBoolean("share_show_add", bindings.advertise.isChecked)
             setBoolean("share_show_reference", bindings.toggleShowReference.isChecked)
             setBoolean("share_abbreviate_reference", bindings.toggleAbbreviateReference.isChecked)
@@ -122,6 +125,7 @@ class ShareWidget(context: Context, attributeSet: AttributeSet?, val selection: 
         bindings.toggleShowVersion.isEnabled = bindings.toggleShowReference.isChecked
         bindings.toggleShowReferenceAtFront.isEnabled = bindings.toggleShowReference.isChecked
         bindings.toggleShowEllipsis.isEnabled = bindings.toggleShowSelectionOnly.isChecked
+        bindings.toggleSuperscriptVersenumbers.isEnabled = bindings.toggleVersenumbers.isChecked
     }
 
     /**

--- a/app/src/main/java/net/bible/android/view/util/widget/ShareWidget.kt
+++ b/app/src/main/java/net/bible/android/view/util/widget/ShareWidget.kt
@@ -50,11 +50,11 @@ class ShareWidget(context: Context, attributeSet: AttributeSet?, val selection: 
             if (!selection.hasRange) {
                 toggleShowSelectionOnly.visibility = View.GONE
                 toggleShowEllipsis.visibility = View.GONE
+                toggleVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_verse_numbers", true)
+                toggleSuperscriptVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_superscript_verse_numbers", false)
             }
 
             // apply isChecked to toggles based on settings
-            toggleVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_verse_numbers", true)
-            toggleSuperscriptVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_superscript_verse_numbers", false)
             advertise.isChecked = CommonUtils.settings.getBoolean("share_show_add", true)
             toggleShowReference.isChecked = CommonUtils.settings.getBoolean("share_show_reference", true)
             toggleAbbreviateReference.isChecked = CommonUtils.settings.getBoolean("share_abbreviate_reference", true)

--- a/app/src/main/java/net/bible/android/view/util/widget/ShareWidget.kt
+++ b/app/src/main/java/net/bible/android/view/util/widget/ShareWidget.kt
@@ -50,11 +50,11 @@ class ShareWidget(context: Context, attributeSet: AttributeSet?, val selection: 
             if (!selection.hasRange) {
                 toggleShowSelectionOnly.visibility = View.GONE
                 toggleShowEllipsis.visibility = View.GONE
-                toggleVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_verse_numbers", true)
-                toggleSuperscriptVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_superscript_verse_numbers", false)
             }
 
             // apply isChecked to toggles based on settings
+            toggleVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_verse_numbers", true)
+            toggleSuperscriptVersenumbers.isChecked = CommonUtils.settings.getBoolean("share_superscript_verse_numbers", false)
             advertise.isChecked = CommonUtils.settings.getBoolean("share_show_add", true)
             toggleShowReference.isChecked = CommonUtils.settings.getBoolean("share_show_reference", true)
             toggleAbbreviateReference.isChecked = CommonUtils.settings.getBoolean("share_abbreviate_reference", true)

--- a/app/src/main/java/net/bible/service/common/ABStringUtils.kt
+++ b/app/src/main/java/net/bible/service/common/ABStringUtils.kt
@@ -38,8 +38,8 @@ object ABStringUtils : StringUtils() {
         return true
     }
 
+    private val superscripts = charArrayOf('⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹')
     fun toSuperscript(anyString: String): String {
-        val superscripts = charArrayOf('⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹')
         return anyString.map { char ->
             if (char in '0'..'9') superscripts[char - '0'] else char
         }.joinToString("")

--- a/app/src/main/java/net/bible/service/common/ABStringUtils.kt
+++ b/app/src/main/java/net/bible/service/common/ABStringUtils.kt
@@ -37,4 +37,11 @@ object ABStringUtils : StringUtils() {
         }
         return true
     }
+
+    fun toSuperscript(anyString: String): String {
+        val superscripts = charArrayOf('⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹')
+        return anyString.map { char ->
+            if (char in '0'..'9') superscripts[char - '0'] else char
+        }.joinToString("")
+    }
 }

--- a/app/src/main/java/net/bible/service/common/CommonUtils.kt
+++ b/app/src/main/java/net/bible/service/common/CommonUtils.kt
@@ -501,15 +501,16 @@ object CommonUtils : CommonUtilsBase() {
         selection,
         showVerseNumbers = settings.getBoolean("share_verse_numbers", true),
         advertiseApp = settings.getBoolean("share_show_add", true),
+        showReference = settings.getBoolean("share_show_reference", true),
+        showReferenceAtFront = settings.getBoolean("share_show_reference_at_front", true),
         abbreviateReference = settings.getBoolean("share_abbreviate_reference", true),
         showNotes = settings.getBoolean("show_notes", true),
         showVersion = settings.getBoolean("share_show_version", true),
-        showReference = settings.getBoolean("share_show_reference", true),
-        showReferenceAtFront = settings.getBoolean("share_show_reference_at_front", true),
         showSelectionOnly = settings.getBoolean("show_selection_only", true),
         showEllipsis = settings.getBoolean("show_ellipsis", true),
         showQuotes = settings.getBoolean("share_show_quotes", false),
-        separateVersesWithNewlines = settings.getBoolean("share_separate_verses_newlines", false)
+        separateVersesWithNewlines = settings.getBoolean("share_separate_verses_newlines", false),
+        useSuperscriptVerseNumbers = settings.getBoolean("share_superscript_verse_numbers", false)
     )
 
     fun getFreeSpace(path: String): Long {

--- a/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
+++ b/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
@@ -659,7 +659,7 @@ object SwordContentFacade {
             return ""
         var verseNum = verse.toString()
         if (useSuperscriptVerseNumbers)
-            return ABStringUtils.toSuperscript(verseNum) + " "
+            return ABStringUtils.toSuperscript(verseNum) + " "
         else
             return "${verseNum}. "
     }

--- a/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
+++ b/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
@@ -657,11 +657,13 @@ object SwordContentFacade {
     private fun formatVerseNumber(verse: Int?, useSuperscriptVerseNumbers: Boolean): String {
         if (verse == null)
             return ""
-        var verseNum = verse.toString()
-        if (useSuperscriptVerseNumbers)
-            return ABStringUtils.toSuperscript(verseNum) + " "
-        else
+        val verseNum = verse.toString()
+        if (useSuperscriptVerseNumbers) {
+            val hairSpace = "\u200A"
+            return ABStringUtils.toSuperscript(verseNum) + hairSpace
+        } else {
             return "${verseNum}. "
+        }
     }
 
     private fun getSpeakCommandsForVerse(settings: SpeakSettings, book: Book, key: Key): ArrayList<SpeakCommand> = try {

--- a/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
+++ b/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
@@ -655,7 +655,9 @@ object SwordContentFacade {
     }
 
     private fun formatVerseNumber(verse: Int?, useSuperscriptVerseNumbers: Boolean): String {
-        var verseNum = verse?.toString() ?: ""
+        if (verse == null)
+            return ""
+        var verseNum = verse.toString()
         if (useSuperscriptVerseNumbers)
             return ABStringUtils.toSuperscript(verseNum) + " "
         else

--- a/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
+++ b/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
@@ -26,6 +26,7 @@ import net.bible.android.activity.R
 import net.bible.android.database.bookmarks.KJVA
 import net.bible.android.database.bookmarks.SpeakSettings
 import net.bible.android.view.activity.page.Selection
+import net.bible.service.common.ABStringUtils
 import net.bible.service.common.Logger
 import net.bible.service.common.htmlToSpan
 import net.bible.service.common.useSaxBuilder
@@ -62,7 +63,6 @@ import org.jdom2.Element
 import org.jdom2.Namespace
 import org.jdom2.Text
 import org.jdom2.filter.Filters
-import org.jdom2.input.SAXBuilder
 import org.jdom2.xpath.XPathFactory
 import org.xml.sax.ContentHandler
 import java.io.StringReader
@@ -486,6 +486,9 @@ object SwordContentFacade {
      * @param showQuotes
      * if true, quotation marks surround the returned String
      *
+     * @param useSuperscriptVerseNumbers
+     * if true, use unicode superscript verse numbers
+     *
      * @return
      * the selected text, with markup according to options
      */
@@ -502,6 +505,7 @@ object SwordContentFacade {
         showEllipsis: Boolean = true,
         showQuotes: Boolean = true,
         separateVersesWithNewlines: Boolean = false,
+        useSuperscriptVerseNumbers: Boolean = false
     ): String {
 
         class VerseAndText(val verse: Verse, val text: String)
@@ -527,7 +531,7 @@ object SwordContentFacade {
 
         var startVerseNumber = ""
         if (showVerseNumbers && verseTexts.size > 1 && (!showReferenceAtFront || separateVersesWithNewlines)) {
-            startVerseNumber = "${selection.verseRange?.start?.verse}. "
+            startVerseNumber = formatVerseNumber(selection.verseRange?.start?.verse, useSuperscriptVerseNumbers)
         }
         if (showSelectionOnly && startOffset > 0 && showEllipsis) {
             startVerseNumber = "$startVerseNumber..."
@@ -585,7 +589,10 @@ object SwordContentFacade {
             verseTexts.size > 1 -> {
                 startVerse = startVerse.slice(startOffset until startVerse.length)
                 val lastVerse = verseTexts.last()
-                val endVerseNum = if (showVerseNumbers) "${lastVerse.verse.verse}. " else ""
+                var endVerseNum = if (showVerseNumbers) {
+                    formatVerseNumber(lastVerse.verse.verse, useSuperscriptVerseNumbers)
+                } else
+                    ""
                 val endVerse = lastVerse.text.slice(0 until min(lastVerse.text.length, endOffset))
                 val end = lastVerse.text.slice(endOffset until lastVerse.text.length)
                 
@@ -593,7 +600,9 @@ object SwordContentFacade {
                     var result = startVerse.trimEnd()
                     if (verseTexts.size > 2) {
                         val middleVerses = verseTexts.slice(1 until verseTexts.size - 1).map {
-                            if (showVerseNumbers && it.verse.verse != 0) "${it.verse.verse}. ${it.text}" else it.text
+                            if (showVerseNumbers && it.verse.verse != 0) {
+                                formatVerseNumber(it.verse.verse, useSuperscriptVerseNumbers) + it.text
+                            } else it.text
                         }
                         for (middleVerse in middleVerses) {
                             result += "\n\n$middleVerse"
@@ -604,7 +613,9 @@ object SwordContentFacade {
                 } else {
                     var middleVerses = if (verseTexts.size > 2) {
                         verseTexts.slice(1 until verseTexts.size - 1).joinToString(" ") {
-                            if (showVerseNumbers && it.verse.verse != 0) "${it.verse.verse}. ${it.text}" else it.text
+                            if (showVerseNumbers && it.verse.verse != 0) {
+                                formatVerseNumber(it.verse.verse, useSuperscriptVerseNumbers) + it.text
+                            } else it.text
                         }
                     } else ""
                     if (middleVerses.isNotEmpty()) {
@@ -641,6 +652,14 @@ object SwordContentFacade {
         } else {
             "$verseText$notes$advertise"
         }
+    }
+
+    private fun formatVerseNumber(verse: Int?, useSuperscriptVerseNumbers: Boolean): String {
+        var verseNum = verse?.toString() ?: ""
+        if (useSuperscriptVerseNumbers)
+            return ABStringUtils.toSuperscript(verseNum) + " "
+        else
+            return "${verseNum}. "
     }
 
     private fun getSpeakCommandsForVerse(settings: SpeakSettings, book: Book, key: Key): ArrayList<SpeakCommand> = try {

--- a/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
+++ b/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
@@ -589,7 +589,7 @@ object SwordContentFacade {
             verseTexts.size > 1 -> {
                 startVerse = startVerse.slice(startOffset until startVerse.length)
                 val lastVerse = verseTexts.last()
-                var endVerseNum = if (showVerseNumbers) {
+                val endVerseNum = if (showVerseNumbers) {
                     formatVerseNumber(lastVerse.verse.verse, useSuperscriptVerseNumbers)
                 } else
                     ""

--- a/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
+++ b/app/src/main/java/net/bible/service/sword/SwordContentFacade.kt
@@ -487,7 +487,7 @@ object SwordContentFacade {
      * if true, quotation marks surround the returned String
      *
      * @param useSuperscriptVerseNumbers
-     * if true, use unicode superscript verse numbers
+     * if true, use Unicode superscript verse numbers
      *
      * @return
      * the selected text, with markup according to options

--- a/app/src/main/res/layout/share_verses.xml
+++ b/app/src/main/res/layout/share_verses.xml
@@ -45,21 +45,21 @@
             android:id="@+id/toggleAbbreviateReference"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
+            android:layout_marginStart="10dp"
             android:padding="7dip"
             android:text="@string/abbreviate_reference" />
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/toggleShowVersion"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
+            android:layout_marginStart="10dp"
             android:padding="7dip"
             android:text="@string/show_version_name" />
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/toggleShowReferenceAtFront"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
+            android:layout_marginStart="10dp"
             android:padding="7dip"
             android:text="@string/show_reference_at_front" />
         <androidx.appcompat.widget.SwitchCompat
@@ -104,7 +104,7 @@
             android:id="@+id/toggleShowEllipsis"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
+            android:layout_marginStart="10dp"
             android:padding="7dip"
             android:text="@string/show_ellipsis" />
         <androidx.appcompat.widget.SwitchCompat

--- a/app/src/main/res/layout/share_verses.xml
+++ b/app/src/main/res/layout/share_verses.xml
@@ -69,6 +69,13 @@
             android:padding="7dip"
             android:text="@string/show_versenumbers" />
         <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleSuperscriptVersenumbers"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:padding="7dip"
+            android:text="@string/use_superscript_versenumbers" />
+        <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/toggleShowQuotes"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -974,6 +974,7 @@
     <string name="generic_share">Share</string>
     <string name="share_verse_menu_title">Share / copy…</string>
     <string name="show_versenumbers">Show verse numbers</string>
+    <string name="use_superscript_versenumbers">Use superscript verse numbers</string>
     <string name="show_full_verses">Show full verses</string>
     <string name="show_selection_only">Show selected text only</string>
     <string name="advertise_app">Advertise app</string>

--- a/app/src/test/java/net/bible/service/sword/SwordContentFacadeTest.kt
+++ b/app/src/test/java/net/bible/service/sword/SwordContentFacadeTest.kt
@@ -733,7 +733,7 @@ Psa 83:1, ESV2011"""
             verseRangeStr = "Ps.43.1-2",
             offsetRange = 0..100,
             showWholeVerse = true,
-            compareText = "“¹ Judge me, O God, and plead my cause against an ungodly nation: O deliver me from the deceitful and unjust man. ² For thou art the God of my strength: why dost thou cast me off? why go I mourning because of the oppression of the enemy?” (Psa 43:1-2, KJV)",
+            compareText = "“¹\u200AJudge me, O God, and plead my cause against an ungodly nation: O deliver me from the deceitful and unjust man. ²\u200AFor thou art the God of my strength: why dost thou cast me off? why go I mourning because of the oppression of the enemy?” (Psa 43:1-2, KJV)",
             advertiseApp = false,
             showReference = true,
             abbreviateReference = true,

--- a/app/src/test/java/net/bible/service/sword/SwordContentFacadeTest.kt
+++ b/app/src/test/java/net/bible/service/sword/SwordContentFacadeTest.kt
@@ -378,7 +378,8 @@ class TestShare {
         showVersion: Boolean = true,
         showEllipsis: Boolean = true,
         showQuotes: Boolean = true,
-        separateVersesWithNewlines: Boolean = false
+        separateVersesWithNewlines: Boolean = false,
+        useSuperscriptVerseNumbers: Boolean = false
     ) {
 
         val book = Books.installed().getBook(initials) as SwordBook
@@ -408,6 +409,7 @@ class TestShare {
             showVersion = showVersion,
             showEllipsis = showEllipsis,
             separateVersesWithNewlines = separateVersesWithNewlines,
+            useSuperscriptVerseNumbers = useSuperscriptVerseNumbers
         )
 
         assertThat(text, equalTo(compareText))
@@ -722,5 +724,24 @@ Psa 83:1, ESV2011"""
             showReference = false,
             separateVersesWithNewlines = true,
             compareText = """“O God, do not keep silence; do not hold your peace or be still, O God!”"""
+        )
+
+    @Test
+    fun testShareUsingSuperscriptVerseNumbers() =
+        testShare(
+            initials = "KJV",
+            verseRangeStr = "Ps.43.1-2",
+            offsetRange = 0..100,
+            showWholeVerse = true,
+            compareText = "“¹ Judge me, O God, and plead my cause against an ungodly nation: O deliver me from the deceitful and unjust man. ² For thou art the God of my strength: why dost thou cast me off? why go I mourning because of the oppression of the enemy?” (Psa 43:1-2, KJV)",
+            advertiseApp = false,
+            showReference = true,
+            abbreviateReference = true,
+            showVersion = true,
+            showReferenceAtFront = false,
+            showVerseNumbers = true,
+            showQuotes = true,
+            showNotes = false,
+            useSuperscriptVerseNumbers = true
         )
 }


### PR DESCRIPTION
**Describe the pull request content**
This code allows the use of unicode superscript as verse numbers when sharing/copying verses.

**Screenshots**
<img width="1264" height="1680" alt="Image" src="https://github.com/user-attachments/assets/64d259e7-36c9-459e-aa47-5a296b4f3e24" />
