### PR TITLE
AI: regenerate with instructions + custom prompt

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/ai/LlmDialogHelper.kt
+++ b/app/src/main/java/net/bible/android/view/activity/ai/LlmDialogHelper.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2026 Sykerö Software / Tuomas Airaksinen and the AndBible contributors.
+ *
+ * This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+ *
+ * AndBible is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with AndBible.
+ * If not, see http://www.gnu.org/licenses/.
+ */
+
+package net.bible.android.view.activity.ai
+
+import android.content.Intent
+import android.text.InputType
+import android.util.Log
+import android.widget.CheckBox
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import net.bible.android.activity.R
+import net.bible.android.control.page.ErrorDocument
+import net.bible.android.control.page.ErrorSeverity
+import net.bible.android.database.IdType
+import net.bible.android.view.activity.page.BibleView
+import net.bible.android.view.activity.page.MainBibleActivity
+import net.bible.android.view.activity.page.Selection
+import net.bible.service.llm.AgentPrompt
+import net.bible.service.llm.AgentTool
+import net.bible.service.llm.PromptContext
+import net.bible.service.llm.PromptRepository
+import net.bible.service.llm.agent.AgentSessionManager
+
+private const val TAG = "LlmDialogHelper"
+
+/**
+ * Handles LLM-related dialogs: prompt selection, custom prompt entry, and regeneration.
+ * Extracted from MainBibleActivity and BibleJavascriptInterface to avoid bloating those classes.
+ */
+class LlmDialogHelper(private val activity: MainBibleActivity) {
+
+    private var pendingCustomPromptSelection: Selection? = null
+
+    val promptEditLauncher: ActivityResultLauncher<Intent> = activity.registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val selection = pendingCustomPromptSelection
+        pendingCustomPromptSelection = null
+        if (result.resultCode == android.app.Activity.RESULT_OK && selection != null) {
+            val promptIdStr = result.data?.getStringExtra(PromptEditActivity.RESULT_PROMPT_ID)
+            if (promptIdStr != null) {
+                activity.lifecycleScope.launch(Dispatchers.IO) {
+                    val prompt = PromptRepository.promptById(IdType(promptIdStr))
+                    if (prompt != null) {
+                        AgentSessionManager.executePrompt(prompt, selection)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Show LLM prompt selector dialog with a "Custom prompt…" option at the end.
+     */
+    fun showPromptSelector(selection: Selection, context: PromptContext = PromptContext.VERSE_SELECTION) {
+        activity.lifecycleScope.launch(Dispatchers.IO) {
+            val prompts = PromptRepository.promptsForContext(context)
+            val promptNames = prompts.map { it.name }.toMutableList()
+            promptNames.add(activity.getString(R.string.custom_prompt))
+
+            launch(Dispatchers.Main) {
+                AlertDialog.Builder(activity)
+                    .setTitle(R.string.select_llm_prompt)
+                    .setItems(promptNames.toTypedArray()) { _, which ->
+                        if (which < prompts.size) {
+                            executePrompt(prompts[which], selection)
+                        } else {
+                            showCustomPromptDialog(selection, context)
+                        }
+                    }
+                    .setNegativeButton(R.string.cancel, null)
+                    .show()
+            }
+        }
+    }
+
+    /**
+     * Show dialog for entering a custom prompt, with option to save it.
+     */
+    fun showCustomPromptDialog(selection: Selection, context: PromptContext) {
+        val layout = LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(48, 32, 48, 16)
+        }
+        val editText = EditText(activity).apply {
+            setHint(R.string.custom_prompt_hint)
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            minLines = 4
+        }
+        val saveCheckBox = CheckBox(activity).apply {
+            setText(R.string.save_as_new_prompt)
+        }
+        layout.addView(editText)
+        layout.addView(saveCheckBox)
+
+        AlertDialog.Builder(activity)
+            .setTitle(R.string.custom_prompt)
+            .setView(layout)
+            .setPositiveButton(R.string.okay) { _, _ ->
+                val template = editText.text.toString().trim()
+                if (template.isEmpty()) return@setPositiveButton
+
+                if (saveCheckBox.isChecked) {
+                    launchPromptEditForExecution(template, selection, context)
+                } else {
+                    val transientPrompt = AgentPrompt(
+                        name = template.take(50),
+                        promptTemplate = template,
+                        showIn = setOf(context),
+                        deniedTools = setOf(AgentTool.FINISH_WITHOUT_DOCUMENT)
+                    )
+                    executePrompt(transientPrompt, selection)
+                }
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    /**
+     * Show regenerate dialog with optional additional instructions and keep previous checkbox.
+     */
+    fun showRegenerateDialog(pageId: IdType, bibleView: BibleView) {
+        val layout = LinearLayout(activity).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+        val editText = EditText(activity).apply {
+            setHint(R.string.ai_regenerate_instructions_hint)
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            minLines = 3
+        }
+        val keepPreviousCheckBox = CheckBox(activity).apply {
+            setText(R.string.ai_regenerate_keep_previous)
+        }
+        layout.addView(editText)
+        layout.addView(keepPreviousCheckBox)
+
+        AlertDialog.Builder(activity)
+            .setTitle(R.string.ai_regenerate_title)
+            .setView(layout)
+            .setPositiveButton(R.string.ai_document_regenerate) { _, _ ->
+                val instructions = editText.text.toString().trim().ifEmpty { null }
+                val keepPrevious = keepPreviousCheckBox.isChecked
+
+                activity.lifecycleScope.launch {
+                    bibleView.loadDocument(
+                        ErrorDocument(
+                            activity.getString(R.string.ai_document_regenerating),
+                            ErrorSeverity.NORMAL
+                        )
+                    )
+                }
+                activity.lifecycleScope.launch(Dispatchers.IO) {
+                    val success = AgentSessionManager.regenerateAIDocument(
+                        pageId,
+                        targetWindowId = bibleView.window.id,
+                        additionalInstructions = instructions,
+                        keepPrevious = keepPrevious
+                    )
+                    if (!success) {
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(activity, R.string.error_occurred, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    /**
+     * Execute a prompt with proper error handling and session tracking.
+     */
+    fun executePrompt(prompt: AgentPrompt, selection: Selection) {
+        val workspaceId = activity.windowControl.windowRepository.id
+        val job = activity.lifecycleScope.launch(Dispatchers.IO) {
+            try {
+                AgentSessionManager.executePrompt(prompt, selection)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "LLM prompt execution failed", e)
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(activity, R.string.error_occurred, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+        AgentSessionManager.getOrCreateSession(workspaceId).job = job
+    }
+
+    private fun launchPromptEditForExecution(template: String, selection: Selection, context: PromptContext) {
+        pendingCustomPromptSelection = selection
+        val intent = Intent(activity, PromptEditActivity::class.java).apply {
+            putExtra(PromptEditActivity.EXTRA_PROMPT_TEMPLATE, template)
+            putExtra(PromptEditActivity.EXTRA_EXECUTE_AFTER_SAVE, true)
+            putExtra(PromptEditActivity.EXTRA_DEFAULT_CONTEXT, context.name)
+        }
+        promptEditLauncher.launch(intent)
+    }
+}

--- a/app/src/main/java/net/bible/android/view/activity/ai/PromptEditActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/ai/PromptEditActivity.kt
@@ -81,6 +81,10 @@ class PromptEditActivity : ActivityBase() {
 
     companion object {
         const val EXTRA_PROMPT_ID = "prompt_id"
+        const val EXTRA_PROMPT_TEMPLATE = "prompt_template"
+        const val EXTRA_EXECUTE_AFTER_SAVE = "execute_after_save"
+        const val EXTRA_DEFAULT_CONTEXT = "default_context"
+        const val RESULT_PROMPT_ID = "result_prompt_id"
         private const val CUSTOM_SENTINEL = "\u0000custom"
     }
 
@@ -140,6 +144,25 @@ class PromptEditActivity : ActivityBase() {
             title = getString(R.string.new_prompt)
             // Set default value for strictContextMatching on new prompts
             binding.checkStrictContextMatching.isChecked = true
+
+            // Pre-fill template from custom prompt dialog
+            intent.getStringExtra(EXTRA_PROMPT_TEMPLATE)?.let { template ->
+                binding.promptTemplate.setText(template)
+            }
+
+            // Pre-check the context checkbox matching where the prompt was initiated
+            intent.getStringExtra(EXTRA_DEFAULT_CONTEXT)?.let { contextName ->
+                try {
+                    when (PromptContext.valueOf(contextName)) {
+                        PromptContext.VERSE_SELECTION -> binding.checkVerseSelection.isChecked = true
+                        PromptContext.TEXT_SELECTION -> binding.checkTextSelection.isChecked = true
+                        PromptContext.WINDOW_MENU -> binding.checkWindowMenu.isChecked = true
+                        PromptContext.WORKSPACE_MENU -> binding.checkWorkspaceMenu.isChecked = true
+                        PromptContext.NOTE_EDITOR -> binding.checkNoteEditor.isChecked = true
+                    }
+                } catch (_: IllegalArgumentException) { }
+            }
+
             captureInitialState()
         }
     }
@@ -303,6 +326,7 @@ class PromptEditActivity : ActivityBase() {
         val selectedModelOverride = getSelectedModelOverride()
 
         lifecycleScope.launch {
+            var savedPromptId: IdType? = null
             withContext(Dispatchers.IO) {
                 if (isNewPrompt) {
                     val newPrompt = AgentPrompt(
@@ -318,6 +342,7 @@ class PromptEditActivity : ActivityBase() {
                         providerConfigId = selectedProviderConfigId,
                     )
                     PromptRepository.insertPrompt(newPrompt)
+                    savedPromptId = newPrompt.id
                 } else {
                     prompt?.let {
                         it.name = name
@@ -331,10 +356,14 @@ class PromptEditActivity : ActivityBase() {
                         it.modelOverride = selectedModelOverride
                         it.providerConfigId = selectedProviderConfigId
                         PromptRepository.updatePrompt(it)
+                        savedPromptId = it.id
                     }
                 }
             }
 
+            if (intent.getBooleanExtra(EXTRA_EXECUTE_AFTER_SAVE, false) && savedPromptId != null) {
+                setResult(RESULT_OK, Intent().putExtra(RESULT_PROMPT_ID, savedPromptId.toString()))
+            }
             finish()
         }
     }

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
@@ -19,13 +19,9 @@ package net.bible.android.view.activity.page
 
 import android.app.AlertDialog
 import android.content.Intent
-import android.text.InputType
 import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.webkit.JavascriptInterface
-import android.widget.CheckBox
-import android.widget.EditText
-import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
@@ -54,7 +50,6 @@ import net.bible.android.control.versification.toVerseRange
 import net.bible.android.database.IdType
 import net.bible.android.database.bookmarks.BookmarkEntities
 import net.bible.android.database.bookmarks.BookmarkEntities.EditAction
-import net.bible.android.database.bookmarks.BookmarkEntities.EditActionMode
 import net.bible.android.database.bookmarks.KJVA
 import net.bible.android.view.activity.base.ActivityBase
 import net.bible.android.view.activity.base.IntentHelper
@@ -70,7 +65,6 @@ import net.bible.service.common.htmlToSpan
 import net.bible.service.sword.BookAndKey
 import net.bible.service.sword.SwordDocumentFacade
 import net.bible.service.sword.epub.EpubBackend
-import net.bible.service.llm.agent.AgentSessionManager
 import net.bible.service.sword.mydocument.MyDocumentBookManager
 import net.bible.service.sword.mybible.myBibleIntToBibleBook
 import net.bible.service.sword.mysword.mySwordIntToBibleBook
@@ -761,51 +755,7 @@ class BibleJavascriptInterface(
     fun regenerateMyDocumentPage(pageId: String) {
         val id = IdType(pageId)
         scope.launch(Dispatchers.Main) {
-            val layout = LinearLayout(mainBibleActivity).apply {
-                orientation = LinearLayout.VERTICAL
-                setPadding(48, 32, 48, 16)
-            }
-            val editText = EditText(mainBibleActivity).apply {
-                setHint(R.string.ai_regenerate_instructions_hint)
-                inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
-                minLines = 3
-            }
-            val keepPreviousCheckBox = CheckBox(mainBibleActivity).apply {
-                setText(R.string.ai_regenerate_keep_previous)
-            }
-            layout.addView(editText)
-            layout.addView(keepPreviousCheckBox)
-
-            AlertDialog.Builder(mainBibleActivity)
-                .setTitle(R.string.ai_regenerate_title)
-                .setView(layout)
-                .setPositiveButton(R.string.ai_document_regenerate) { _, _ ->
-                    val instructions = editText.text.toString().trim().ifEmpty { null }
-                    val keepPrevious = keepPreviousCheckBox.isChecked
-
-                    scope.launch {
-                        val errorDoc = ErrorDocument(
-                            mainBibleActivity.getString(R.string.ai_document_regenerating),
-                            ErrorSeverity.NORMAL
-                        )
-                        bibleView.loadDocument(errorDoc)
-                    }
-                    scope.launch(Dispatchers.IO) {
-                        val success = AgentSessionManager.regenerateAIDocument(
-                            id,
-                            targetWindowId = bibleView.window.id,
-                            additionalInstructions = instructions,
-                            keepPrevious = keepPrevious
-                        )
-                        if (!success) {
-                            withContext(Dispatchers.Main) {
-                                Toast.makeText(mainBibleActivity, R.string.error_occurred, Toast.LENGTH_SHORT).show()
-                            }
-                        }
-                    }
-                }
-                .setNegativeButton(R.string.cancel, null)
-                .show()
+            mainBibleActivity.llmDialogHelper.showRegenerateDialog(id, bibleView)
         }
     }
 

--- a/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/BibleJavascriptInterface.kt
@@ -19,9 +19,13 @@ package net.bible.android.view.activity.page
 
 import android.app.AlertDialog
 import android.content.Intent
+import android.text.InputType
 import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.webkit.JavascriptInterface
+import android.widget.CheckBox
+import android.widget.EditText
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
@@ -756,20 +760,52 @@ class BibleJavascriptInterface(
     @JavascriptInterface
     fun regenerateMyDocumentPage(pageId: String) {
         val id = IdType(pageId)
-        scope.launch {
-            val errorDoc = ErrorDocument(
-                mainBibleActivity.getString(R.string.ai_document_regenerating),
-                ErrorSeverity.NORMAL
-            )
-            bibleView.loadDocument(errorDoc)
-        }
-        scope.launch(Dispatchers.IO) {
-            val success = AgentSessionManager.regenerateAIDocument(id, targetWindowId = bibleView.window.id)
-            if (!success) {
-                withContext(Dispatchers.Main) {
-                    Toast.makeText(mainBibleActivity, R.string.error_occurred, Toast.LENGTH_SHORT).show()
-                }
+        scope.launch(Dispatchers.Main) {
+            val layout = LinearLayout(mainBibleActivity).apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(48, 32, 48, 16)
             }
+            val editText = EditText(mainBibleActivity).apply {
+                setHint(R.string.ai_regenerate_instructions_hint)
+                inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+                minLines = 3
+            }
+            val keepPreviousCheckBox = CheckBox(mainBibleActivity).apply {
+                setText(R.string.ai_regenerate_keep_previous)
+            }
+            layout.addView(editText)
+            layout.addView(keepPreviousCheckBox)
+
+            AlertDialog.Builder(mainBibleActivity)
+                .setTitle(R.string.ai_regenerate_title)
+                .setView(layout)
+                .setPositiveButton(R.string.ai_document_regenerate) { _, _ ->
+                    val instructions = editText.text.toString().trim().ifEmpty { null }
+                    val keepPrevious = keepPreviousCheckBox.isChecked
+
+                    scope.launch {
+                        val errorDoc = ErrorDocument(
+                            mainBibleActivity.getString(R.string.ai_document_regenerating),
+                            ErrorSeverity.NORMAL
+                        )
+                        bibleView.loadDocument(errorDoc)
+                    }
+                    scope.launch(Dispatchers.IO) {
+                        val success = AgentSessionManager.regenerateAIDocument(
+                            id,
+                            targetWindowId = bibleView.window.id,
+                            additionalInstructions = instructions,
+                            keepPrevious = keepPrevious
+                        )
+                        if (!success) {
+                            withContext(Dispatchers.Main) {
+                                Toast.makeText(mainBibleActivity, R.string.error_occurred, Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    }
+                }
+                .setNegativeButton(R.string.cancel, null)
+                .show()
         }
     }
 

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -56,14 +56,9 @@ import android.view.WindowInsetsController
 import android.view.WindowManager
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
-import android.text.InputType
-import android.widget.CheckBox
-import android.widget.EditText
 import android.widget.ImageButton
-import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuPopupHelper
@@ -122,7 +117,7 @@ import net.bible.android.view.activity.base.CustomTitlebarActivityBase
 import net.bible.android.view.activity.base.IntentHelper
 import net.bible.android.view.activity.base.SharedActivityState
 import net.bible.android.view.activity.base.firstTime
-import net.bible.android.view.activity.ai.PromptEditActivity
+import net.bible.android.view.activity.ai.LlmDialogHelper
 import net.bible.android.view.activity.bookmark.Bookmarks
 import net.bible.android.view.activity.mydocuments.MyDocumentPagesActivity
 import net.bible.android.view.activity.mydocuments.MyDocumentsActivity
@@ -157,11 +152,8 @@ import net.bible.service.cloudsync.CloudSync
 import net.bible.service.cloudsync.CloudSyncEvent
 import net.bible.service.cloudsync.WorkspaceRefreshRequired
 import net.bible.service.llm.AgentPrompt
-import net.bible.service.llm.AgentTool
-import net.bible.service.download.FakeBookFactory
 import net.bible.service.llm.PromptContext
-import net.bible.service.llm.PromptRepository
-import net.bible.service.llm.agent.AgentSessionManager
+import net.bible.service.download.FakeBookFactory
 import net.bible.service.sword.BookAndKey
 import net.bible.service.sword.BookAndKeySerialized
 import net.bible.service.sword.SwordDocumentFacade
@@ -217,27 +209,8 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
     lateinit var bibleViewFactory: BibleViewFactory
     private lateinit var mainMenuCommandHandler: MenuCommandHandler
 
-    /** Pending selection for custom prompt save+execute flow (stored while PromptEditActivity is open). */
-    private var pendingCustomPromptSelection: Selection? = null
+    val llmDialogHelper = LlmDialogHelper(this)
 
-    private val promptEditLauncher = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        val selection = pendingCustomPromptSelection
-        pendingCustomPromptSelection = null
-        if (result.resultCode == Activity.RESULT_OK && selection != null) {
-            val promptIdStr = result.data?.getStringExtra(PromptEditActivity.RESULT_PROMPT_ID)
-            if (promptIdStr != null) {
-                lifecycleScope.launch(Dispatchers.IO) {
-                    val prompt = PromptRepository.promptById(IdType(promptIdStr))
-                    if (prompt != null) {
-                        AgentSessionManager.executePrompt(prompt, selection)
-                    }
-                }
-            }
-        }
-    }
-    
     private val navigationView: NavigationView by lazy {
         binding.drawerLayout.findViewById(R.id.navigationView)!!
     }
@@ -2233,106 +2206,11 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
         CommonUtils.onyxSupport?.setupOnyxNormal()
     }
 
-    /**
-     * Execute a specific LLM prompt with the given selection.
-     * Called directly when prompt is already selected (e.g., from window button menu).
-     */
-    fun executeLlmPrompt(prompt: AgentPrompt, selection: Selection) {
-        val workspaceId = windowControl.windowRepository.id
-        val job = lifecycleScope.launch(Dispatchers.IO) {
-            try {
-                AgentSessionManager.executePrompt(prompt, selection)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Log.e(TAG, "LLM prompt execution failed", e)
-                withContext(Dispatchers.Main) {
-                    Toast.makeText(this@MainBibleActivity, R.string.error_occurred, Toast.LENGTH_SHORT).show()
-                }
-            }
-        }
-        AgentSessionManager.getOrCreateSession(workspaceId).job = job
-    }
+    fun executeLlmPrompt(prompt: AgentPrompt, selection: Selection) =
+        llmDialogHelper.executePrompt(prompt, selection)
 
-    /**
-     * Show LLM prompt selector dialog for the given selection.
-     * Filters prompts by the given context and shows them in a dialog,
-     * with a "Custom prompt…" option at the end.
-     */
-    fun showLlmPromptSelector(selection: Selection, context: PromptContext = PromptContext.VERSE_SELECTION) {
-        lifecycleScope.launch(Dispatchers.IO) {
-            val prompts = PromptRepository.promptsForContext(context)
-            val promptNames = prompts.map { it.name }.toMutableList()
-            promptNames.add(getString(R.string.custom_prompt))
-
-            launch(Dispatchers.Main) {
-                AlertDialog.Builder(this@MainBibleActivity)
-                    .setTitle(R.string.select_llm_prompt)
-                    .setItems(promptNames.toTypedArray()) { _, which ->
-                        if (which < prompts.size) {
-                            val selectedPrompt = prompts[which]
-                            executeLlmPrompt(selectedPrompt, selection)
-                        } else {
-                            showCustomPromptDialog(selection, context)
-                        }
-                    }
-                    .setNegativeButton(R.string.cancel, null)
-                    .show()
-            }
-        }
-    }
-
-    /**
-     * Show dialog for entering a custom prompt, with option to save it.
-     */
-    internal fun showCustomPromptDialog(selection: Selection, context: PromptContext) {
-        val layout = LinearLayout(this).apply {
-            orientation = LinearLayout.VERTICAL
-            setPadding(48, 32, 48, 16)
-        }
-        val editText = EditText(this).apply {
-            setHint(R.string.custom_prompt_hint)
-            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
-            minLines = 4
-        }
-        val saveCheckBox = CheckBox(this).apply {
-            setText(R.string.save_as_new_prompt)
-        }
-        layout.addView(editText)
-        layout.addView(saveCheckBox)
-
-        AlertDialog.Builder(this)
-            .setTitle(R.string.custom_prompt)
-            .setView(layout)
-            .setPositiveButton(R.string.okay) { _, _ ->
-                val template = editText.text.toString().trim()
-                if (template.isEmpty()) return@setPositiveButton
-
-                if (saveCheckBox.isChecked) {
-                    launchPromptEditForExecution(template, selection, context)
-                } else {
-                    val transientPrompt = AgentPrompt(
-                        name = template.take(50),
-                        promptTemplate = template,
-                        showIn = setOf(context),
-                        deniedTools = setOf(AgentTool.FINISH_WITHOUT_DOCUMENT)
-                    )
-                    executeLlmPrompt(transientPrompt, selection)
-                }
-            }
-            .setNegativeButton(R.string.cancel, null)
-            .show()
-    }
-
-    private fun launchPromptEditForExecution(template: String, selection: Selection, context: PromptContext) {
-        pendingCustomPromptSelection = selection
-        val intent = Intent(this, PromptEditActivity::class.java).apply {
-            putExtra(PromptEditActivity.EXTRA_PROMPT_TEMPLATE, template)
-            putExtra(PromptEditActivity.EXTRA_EXECUTE_AFTER_SAVE, true)
-            putExtra(PromptEditActivity.EXTRA_DEFAULT_CONTEXT, context.name)
-        }
-        promptEditLauncher.launch(intent)
-    }
+    fun showLlmPromptSelector(selection: Selection, context: PromptContext = PromptContext.VERSE_SELECTION) =
+        llmDialogHelper.showPromptSelector(selection, context)
 
     companion object {
         var initialized = false

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -157,6 +157,7 @@ import net.bible.service.cloudsync.CloudSync
 import net.bible.service.cloudsync.CloudSyncEvent
 import net.bible.service.cloudsync.WorkspaceRefreshRequired
 import net.bible.service.llm.AgentPrompt
+import net.bible.service.llm.AgentTool
 import net.bible.service.download.FakeBookFactory
 import net.bible.service.llm.PromptContext
 import net.bible.service.llm.PromptRepository
@@ -2313,7 +2314,8 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
                     val transientPrompt = AgentPrompt(
                         name = template.take(50),
                         promptTemplate = template,
-                        showIn = setOf(context)
+                        showIn = setOf(context),
+                        deniedTools = setOf(AgentTool.FINISH_WITHOUT_DOCUMENT)
                     )
                     executeLlmPrompt(transientPrompt, selection)
                 }

--- a/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/MainBibleActivity.kt
@@ -56,9 +56,14 @@ import android.view.WindowInsetsController
 import android.view.WindowManager
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
+import android.text.InputType
+import android.widget.CheckBox
+import android.widget.EditText
 import android.widget.ImageButton
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuPopupHelper
@@ -117,6 +122,7 @@ import net.bible.android.view.activity.base.CustomTitlebarActivityBase
 import net.bible.android.view.activity.base.IntentHelper
 import net.bible.android.view.activity.base.SharedActivityState
 import net.bible.android.view.activity.base.firstTime
+import net.bible.android.view.activity.ai.PromptEditActivity
 import net.bible.android.view.activity.bookmark.Bookmarks
 import net.bible.android.view.activity.mydocuments.MyDocumentPagesActivity
 import net.bible.android.view.activity.mydocuments.MyDocumentsActivity
@@ -209,6 +215,27 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
     lateinit var documentViewManager: DocumentViewManager
     lateinit var bibleViewFactory: BibleViewFactory
     private lateinit var mainMenuCommandHandler: MenuCommandHandler
+
+    /** Pending selection for custom prompt save+execute flow (stored while PromptEditActivity is open). */
+    private var pendingCustomPromptSelection: Selection? = null
+
+    private val promptEditLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val selection = pendingCustomPromptSelection
+        pendingCustomPromptSelection = null
+        if (result.resultCode == Activity.RESULT_OK && selection != null) {
+            val promptIdStr = result.data?.getStringExtra(PromptEditActivity.RESULT_PROMPT_ID)
+            if (promptIdStr != null) {
+                lifecycleScope.launch(Dispatchers.IO) {
+                    val prompt = PromptRepository.promptById(IdType(promptIdStr))
+                    if (prompt != null) {
+                        AgentSessionManager.executePrompt(prompt, selection)
+                    }
+                }
+            }
+        }
+    }
     
     private val navigationView: NavigationView by lazy {
         binding.drawerLayout.findViewById(R.id.navigationView)!!
@@ -2228,51 +2255,81 @@ class MainBibleActivity : CustomTitlebarActivityBase() {
 
     /**
      * Show LLM prompt selector dialog for the given selection.
-     * Filters prompts by VERSE_SELECTION context and shows them in a dialog.
+     * Filters prompts by the given context and shows them in a dialog,
+     * with a "Custom prompt…" option at the end.
      */
-    fun showLlmPromptSelector(selection: Selection) {
+    fun showLlmPromptSelector(selection: Selection, context: PromptContext = PromptContext.VERSE_SELECTION) {
         lifecycleScope.launch(Dispatchers.IO) {
-            val prompts = PromptRepository.promptsForContext(
-                PromptContext.VERSE_SELECTION
-            )
+            val prompts = PromptRepository.promptsForContext(context)
+            val promptNames = prompts.map { it.name }.toMutableList()
+            promptNames.add(getString(R.string.custom_prompt))
 
-            if (prompts.isEmpty()) {
-                launch(Dispatchers.Main) {
-                    Toast.makeText(
-                        this@MainBibleActivity,
-                        R.string.no_llm_prompts_configured,
-                        Toast.LENGTH_SHORT
-                    ).show()
-                }
-                return@launch
-            }
-
-            val promptNames = prompts.map { it.name }.toTypedArray()
             launch(Dispatchers.Main) {
                 AlertDialog.Builder(this@MainBibleActivity)
                     .setTitle(R.string.select_llm_prompt)
-                    .setItems(promptNames) { _, which ->
-                        val selectedPrompt = prompts[which]
-                        // Execute via AgentSessionManager
-                        val wsId = windowControl.windowRepository.id
-                        val job = lifecycleScope.launch(Dispatchers.IO) {
-                            try {
-                                AgentSessionManager.executePrompt(selectedPrompt, selection)
-                            } catch (e: CancellationException) {
-                                throw e
-                            } catch (e: Exception) {
-                                Log.e(TAG, "LLM prompt execution failed", e)
-                                withContext(Dispatchers.Main) {
-                                    Toast.makeText(this@MainBibleActivity, R.string.error_occurred, Toast.LENGTH_SHORT).show()
-                                }
-                            }
+                    .setItems(promptNames.toTypedArray()) { _, which ->
+                        if (which < prompts.size) {
+                            val selectedPrompt = prompts[which]
+                            executeLlmPrompt(selectedPrompt, selection)
+                        } else {
+                            showCustomPromptDialog(selection, context)
                         }
-                        AgentSessionManager.getOrCreateSession(wsId).job = job
                     }
                     .setNegativeButton(R.string.cancel, null)
                     .show()
             }
         }
+    }
+
+    /**
+     * Show dialog for entering a custom prompt, with option to save it.
+     */
+    internal fun showCustomPromptDialog(selection: Selection, context: PromptContext) {
+        val layout = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(48, 32, 48, 16)
+        }
+        val editText = EditText(this).apply {
+            setHint(R.string.custom_prompt_hint)
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+            minLines = 4
+        }
+        val saveCheckBox = CheckBox(this).apply {
+            setText(R.string.save_as_new_prompt)
+        }
+        layout.addView(editText)
+        layout.addView(saveCheckBox)
+
+        AlertDialog.Builder(this)
+            .setTitle(R.string.custom_prompt)
+            .setView(layout)
+            .setPositiveButton(R.string.okay) { _, _ ->
+                val template = editText.text.toString().trim()
+                if (template.isEmpty()) return@setPositiveButton
+
+                if (saveCheckBox.isChecked) {
+                    launchPromptEditForExecution(template, selection, context)
+                } else {
+                    val transientPrompt = AgentPrompt(
+                        name = template.take(50),
+                        promptTemplate = template,
+                        showIn = setOf(context)
+                    )
+                    executeLlmPrompt(transientPrompt, selection)
+                }
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    private fun launchPromptEditForExecution(template: String, selection: Selection, context: PromptContext) {
+        pendingCustomPromptSelection = selection
+        val intent = Intent(this, PromptEditActivity::class.java).apply {
+            putExtra(PromptEditActivity.EXTRA_PROMPT_TEMPLATE, template)
+            putExtra(PromptEditActivity.EXTRA_EXECUTE_AFTER_SAVE, true)
+            putExtra(PromptEditActivity.EXTRA_DEFAULT_CONTEXT, context.name)
+        }
+        promptEditLauncher.launch(intent)
     }
 
     companion object {

--- a/app/src/main/java/net/bible/android/view/activity/page/screen/SplitBibleArea.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/screen/SplitBibleArea.kt
@@ -830,13 +830,10 @@ class SplitBibleArea(private val mainBibleActivity: MainBibleActivity): FrameLay
             val llmSubMenu = llmActionsSubMenu.subMenu!!
             llmSubMenu.removeItem(R.id.llmActionItem)
             val prompts = PromptRepository.promptsForContext(PromptContext.WINDOW_MENU)
-            if (prompts.isEmpty()) {
-                llmActionsSubMenu.isVisible = false
-            } else {
-                prompts.forEachIndexed { idx, prompt ->
-                    llmSubMenu.add(Menu.NONE, R.id.llmActionItem, idx, prompt.name)
-                }
+            prompts.forEachIndexed { idx, prompt ->
+                llmSubMenu.add(Menu.NONE, R.id.llmActionItem, idx, prompt.name)
             }
+            // "Custom prompt…" is already defined in the menu XML as llmCustomPromptItem
         } else {
             llmActionsSubMenu.isVisible = false
         }
@@ -1082,6 +1079,15 @@ class SplitBibleArea(private val mainBibleActivity: MainBibleActivity): FrameLay
                         val selection = Selection(book.initials, key.osisRef, -1, -1)
                         mainBibleActivity.executeLlmPrompt(selectedPrompt, selection)
                     }
+                }
+            })
+            R.id.llmCustomPromptItem -> CommandPreference({ _, _, _ ->
+                val currentPage = window.pageManager.currentPage
+                val book = currentPage.currentDocument
+                val key = currentPage.key
+                if (book != null && key != null) {
+                    val selection = Selection(book.initials, key.osisRef, -1, -1)
+                    mainBibleActivity.showCustomPromptDialog(selection, PromptContext.WINDOW_MENU)
                 }
             })
             else -> throw RuntimeException("Illegal menu item")

--- a/app/src/main/java/net/bible/android/view/activity/page/screen/SplitBibleArea.kt
+++ b/app/src/main/java/net/bible/android/view/activity/page/screen/SplitBibleArea.kt
@@ -1087,7 +1087,7 @@ class SplitBibleArea(private val mainBibleActivity: MainBibleActivity): FrameLay
                 val key = currentPage.key
                 if (book != null && key != null) {
                     val selection = Selection(book.initials, key.osisRef, -1, -1)
-                    mainBibleActivity.showCustomPromptDialog(selection, PromptContext.WINDOW_MENU)
+                    mainBibleActivity.llmDialogHelper.showCustomPromptDialog(selection, PromptContext.WINDOW_MENU)
                 }
             })
             else -> throw RuntimeException("Illegal menu item")

--- a/app/src/main/java/net/bible/service/llm/agent/AgentContext.kt
+++ b/app/src/main/java/net/bible/service/llm/agent/AgentContext.kt
@@ -45,7 +45,11 @@ data class AgentContext(
     val promptPermissionMode: PermissionMode? = null,
     /** Per-prompt tool permission overrides (null = no override, use global defaults) */
     val promptAllowedTools: Set<AgentTool>? = null,
-    val promptDeniedTools: Set<AgentTool>? = null
+    val promptDeniedTools: Set<AgentTool>? = null,
+    /** Previous LLM response shown during regeneration, so the LLM can refine its output. */
+    val previousResponse: String? = null,
+    /** User-provided additional instructions for regeneration (e.g., "make it shorter"). */
+    val additionalInstructions: String? = null
 ) {
     val verseRefString: String?
         get() = selectedVerseRange?.osisRef

--- a/app/src/main/java/net/bible/service/llm/agent/AgentExecutor.kt
+++ b/app/src/main/java/net/bible/service/llm/agent/AgentExecutor.kt
@@ -37,7 +37,6 @@ import net.bible.service.llm.ChatMessage
 import net.bible.service.llm.LlmApiAdapter
 import net.bible.service.llm.LlmModelConfig
 import net.bible.service.llm.LlmUsage
-import net.bible.service.llm.PromptRepository
 import net.bible.service.llm.LlmProcessingService
 import net.bible.service.llm.ParsedResponse
 import net.bible.service.llm.ToolCall
@@ -91,16 +90,10 @@ private sealed class ProcessToolsResult {
 class AgentExecutor(
     private val maxIterations: Int = DEFAULT_MAX_ITERATIONS
 ) {
-    fun execute(promptId: IdType, context: AgentContext): Flow<AgentEvent> = flow {
+    fun execute(prompt: AgentPrompt, context: AgentContext): Flow<AgentEvent> = flow {
         emit(AgentEvent.Started)
 
         try {
-            val prompt = PromptRepository.promptById(promptId)
-            if (prompt == null) {
-                emit(AgentEvent.Error(application.getString(R.string.llm_error_prompt_not_found, promptId)))
-                return@flow
-            }
-
             val llmConfig = LlmModelConfig.fromPrompt(prompt)
             val adapter = LlmProcessingService.resolveAdapter(llmConfig)
             val messages = buildInitialMessages(prompt, context)

--- a/app/src/main/java/net/bible/service/llm/agent/AgentExecutor.kt
+++ b/app/src/main/java/net/bible/service/llm/agent/AgentExecutor.kt
@@ -376,6 +376,16 @@ class AgentExecutor(
                 append("\n\n--- Context ---\n")
                 append(context.selectedText)
             }
+
+            // For regeneration: include previous response and additional instructions
+            if (context.previousResponse != null) {
+                append("\n\n--- Previous Response (for reference — improve upon this) ---\n")
+                append(context.previousResponse.take(10000))
+            }
+            if (context.additionalInstructions != null) {
+                append("\n\n--- Additional Instructions ---\n")
+                append(context.additionalInstructions)
+            }
         }
     }
 

--- a/app/src/main/java/net/bible/service/llm/agent/AgentSessionManager.kt
+++ b/app/src/main/java/net/bible/service/llm/agent/AgentSessionManager.kt
@@ -237,7 +237,7 @@ object AgentSessionManager : AgentSessionManagerBase() {
         // Execute via AgentExecutor
         val executor = AgentExecutor()
         try {
-            executor.execute(prompt.id, context).collect { event ->
+            executor.execute(prompt, context).collect { event ->
                 handleAgentEvent(event, session, prompt, context, cacheableContext, usedWriteToolsTracker, targetWindowId)
             }
         } catch (e: CancellationException) {

--- a/app/src/main/java/net/bible/service/llm/agent/AgentSessionManager.kt
+++ b/app/src/main/java/net/bible/service/llm/agent/AgentSessionManager.kt
@@ -191,22 +191,30 @@ object AgentSessionManager : AgentSessionManagerBase() {
     suspend fun executePrompt(
         prompt: AgentPrompt,
         selection: Selection,
-        targetWindowId: IdType? = null
+        targetWindowId: IdType? = null,
+        additionalInstructions: String? = null,
+        previousResponse: String? = null,
+        skipCache: Boolean = false
     ) {
         ensureInitialized()
         val workspaceId = windowControl.windowRepository.id
 
         // Build AgentContext and CacheableContext
-        val context = buildAgentContext(prompt, selection)
+        val context = buildAgentContext(prompt, selection,
+            additionalInstructions = additionalInstructions,
+            previousResponse = previousResponse
+        )
         val cacheableContext = CacheableContext.fromAgentContext(context)
 
-        // Check cache
-        val cached = findCachedPage(prompt, cacheableContext)
-        if (cached != null) {
-            Log.i(TAG, "Cache hit for prompt ${prompt.id}: opening ${cached.pageKey}")
-            // Open cached document directly
-            openAIDocumentResult(MyDocumentBookManager.AI_DOCUMENTS_INITIALS, cached.pageKey, targetWindowId)
-            return
+        // Check cache (skipped during regeneration)
+        if (!skipCache) {
+            val cached = findCachedPage(prompt, cacheableContext)
+            if (cached != null) {
+                Log.i(TAG, "Cache hit for prompt ${prompt.id}: opening ${cached.pageKey}")
+                // Open cached document directly
+                openAIDocumentResult(MyDocumentBookManager.AI_DOCUMENTS_INITIALS, cached.pageKey, targetWindowId)
+                return
+            }
         }
 
         // Start session (prevent concurrent runs)
@@ -273,7 +281,9 @@ object AgentSessionManager : AgentSessionManagerBase() {
 
     private suspend fun buildAgentContext(
         prompt: AgentPrompt,
-        selection: Selection
+        selection: Selection,
+        additionalInstructions: String? = null,
+        previousResponse: String? = null
     ): AgentContext {
         val book = selection.bookInitials?.let { Books.installed().getBook(it) }
         val currentPage = windowControl.activeWindowPageManager.currentPage
@@ -370,7 +380,9 @@ object AgentSessionManager : AgentSessionManagerBase() {
             highlightedText = highlightedText,
             promptPermissionMode = prompt.permissionMode,
             promptAllowedTools = prompt.allowedTools,
-            promptDeniedTools = prompt.deniedTools
+            promptDeniedTools = prompt.deniedTools,
+            previousResponse = previousResponse,
+            additionalInstructions = additionalInstructions
         )
     }
 
@@ -558,7 +570,12 @@ object AgentSessionManager : AgentSessionManagerBase() {
         linkControl.openAIDocument(documentInitials, pageKey)
     }
 
-    suspend fun regenerateAIDocument(pageId: IdType, targetWindowId: IdType? = null): Boolean {
+    suspend fun regenerateAIDocument(
+        pageId: IdType,
+        targetWindowId: IdType? = null,
+        additionalInstructions: String? = null,
+        keepPrevious: Boolean = false
+    ): Boolean {
         ensureInitialized()
         val workspaceId = windowControl.windowRepository.id
         val session = activeSessions[workspaceId]
@@ -598,6 +615,9 @@ object AgentSessionManager : AgentSessionManagerBase() {
             Log.w(TAG, "Cannot regenerate: no cache entry for page: $pageId")
             return false
         }
+
+        // Read previous response before potentially deleting the page
+        val previousContent = dao.getContent(pageId)
 
         val kjvOrdinalStart = cacheEntry.kjvOrdinalStart
         val kjvOrdinalEnd = cacheEntry.kjvOrdinalEnd
@@ -642,9 +662,16 @@ object AgentSessionManager : AgentSessionManagerBase() {
             return false
         }
 
-        // Delete old page first to avoid cache hit, then execute the prompt
-        MyDocumentBookManager.deleteAIDocumentPage(pageId)
-        executePrompt(prompt, selection, targetWindowId = targetWindowId)
+        if (!keepPrevious) {
+            MyDocumentBookManager.deleteAIDocumentPage(pageId)
+        }
+        executePrompt(
+            prompt, selection,
+            targetWindowId = targetWindowId,
+            additionalInstructions = additionalInstructions,
+            previousResponse = previousContent,
+            skipCache = true
+        )
         return true
     }
 

--- a/app/src/main/res/menu/window_popup_menu.xml
+++ b/app/src/main/res/menu/window_popup_menu.xml
@@ -124,6 +124,10 @@
 			<item android:id="@+id/llmActionItem"
 				android:title=""
 				/>
+			<item android:id="@+id/llmCustomPromptItem"
+				android:title="@string/custom_prompt"
+				android:orderInCategory="1000"
+				/>
 		</menu>
 	</item>
 	<item android:id="@+id/copyReference"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1510,6 +1510,9 @@
     <string name="ai_regenerate_instructions_hint">Additional instructions (optional)</string>
     <string name="ai_regenerate_keep_previous">Keep previous version</string>
     <string name="ai_document_delete">Delete</string>
+    <string name="custom_prompt">Custom prompt…</string>
+    <string name="custom_prompt_hint">Enter your prompt</string>
+    <string name="save_as_new_prompt">Save as new prompt</string>
 
     <!-- Default prompts -->
     <string name="default_prompt_translate_to_language">Translate to %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1506,6 +1506,9 @@
     <string name="ai_document_regenerating">Regenerating AI document…</string>
     <string name="ai_document_regenerate_not_implemented">Regeneration will be available in a future update</string>
     <string name="ai_document_regenerate">Regenerate</string>
+    <string name="ai_regenerate_title">Regenerate</string>
+    <string name="ai_regenerate_instructions_hint">Additional instructions (optional)</string>
+    <string name="ai_regenerate_keep_previous">Keep previous version</string>
     <string name="ai_document_delete">Delete</string>
 
     <!-- Default prompts -->


### PR DESCRIPTION
## Summary

- **Regenerate with additional instructions**: When regenerating an AI document, a dialog now appears where the user can provide refinement instructions (e.g., "make it shorter"). The LLM sees the previous response for reference. A "Keep previous version" checkbox optionally preserves the old document.
- **Custom prompt**: A "Custom prompt…" option appears at the end of all AI prompt selection lists (verse selection dialog and window menu). Users can write a free-form prompt on the fly. A "Save as new prompt" checkbox redirects to PromptEditActivity with the template pre-filled; after saving, the prompt executes automatically.

## Changes

- `AgentContext` gets `previousResponse` and `additionalInstructions` fields
- `AgentExecutor.execute()` takes `AgentPrompt` directly instead of re-loading by ID
- `AgentSessionManager.executePrompt()` gains `skipCache` parameter for regeneration
- `BibleJavascriptInterface` shows regenerate dialog with EditText + CheckBox
- `MainBibleActivity` adds custom prompt dialog, `ActivityResultLauncher` for save+execute flow
- `PromptEditActivity` accepts pre-filled template and returns saved prompt ID
- `SplitBibleArea` + menu XML add custom prompt item to window menu

## Test plan

- [ ] Create AI document → regenerate with additional instructions → verify response reflects instructions
- [ ] Regenerate with "Keep previous version" checked → both old and new documents exist
- [ ] Regenerate with empty instructions → works like before but LLM sees previous response
- [ ] Verse selection → "Custom prompt…" → type prompt → executes and creates document
- [ ] Custom prompt with "Save as new prompt" → PromptEditActivity opens with template → save → prompt executes
- [ ] Window menu → "Custom prompt…" appears last → works same as verse selection
- [ ] Custom prompt appears last in both verse selection and window menu lists