### PR TITLE
Fixed mislabled backup form

### DIFF
--- a/app/src/main/res/layout/backup_view.xml
+++ b/app/src/main/res/layout/backup_view.xml
@@ -31,7 +31,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/backup_and_restore"
+            android:text="@string/backup"
             android:textSize="20sp"
             android:textStyle="bold" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -653,6 +653,7 @@
     <string name="backup_application_info">Application file (.APK)</string>
     <string name="backup_database_info">Bookmarks, labels, notes, study pads, reading plans, workspaces etc.</string>
     <string name="backup_document_info">Bibles, commentaries, dictionaries, maps etc.</string>
+    <string name="backup">Backup</string>
     <string name="backup_to">Backup to…</string>
     <string name="backup_restore_from">Restore from…</string>
     <!-- Restore = overwrite existing. Import = merge into existing -->


### PR DESCRIPTION
This did read "Backup & Restore" but that is what the whole view does. This section is just backup. Maybe it was used because there was no string for just "Backup".

<img width="401" height="435" alt="image" src="https://github.com/user-attachments/assets/362e7e9d-fa58-494d-ade0-f79a2860eb50" />
