### PR TITLE
Fix ConcurrentModificationException in saveIntoDb during sync

### DIFF
--- a/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
+++ b/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
@@ -39,6 +39,7 @@ import net.bible.service.common.CommonUtils.getResourceString
 import net.bible.service.history.HistoryManager
 import org.crosswire.jsword.versification.BookName
 import runOnMainBlocking
+import java.util.Date
 import javax.inject.Inject
 import javax.inject.Provider
 import kotlin.math.min
@@ -286,9 +287,6 @@ open class WindowRepository(val scope: CoroutineScope) {
         Log.i(TAG, "saveIntoDb")
         if(!CommonUtils.initialized || !DatabaseContainer.ready) return
         if(stopSpeak) speakControl.stop()
-        workspaceSettings.speakSettings = SpeakSettings.currentSettings
-        SpeakSettings.currentSettings?.save()
-
         val historyManager = historyManagerProvider.get()
 
         data class HistorySnap(val windowId: IdType, val items: List<WorkspaceEntities.HistoryItem>)
@@ -303,6 +301,8 @@ open class WindowRepository(val scope: CoroutineScope) {
         // background threads (e.g. cloud sync, db backup), so snapshot the in-memory state
         // on Main before doing DAO writes on the caller's thread. See #3200.
         val snap = runOnMainBlocking {
+            workspaceSettings.speakSettings = SpeakSettings.currentSettings
+            SpeakSettings.currentSettings?.save()
             val windows = windowList.toList()
             val ws = WorkspaceEntities.Workspace(
                 name = name,
@@ -318,8 +318,7 @@ open class WindowRepository(val scope: CoroutineScope) {
 
             var workspaceToUpdate: WorkspaceEntities.Workspace? = null
             if (ws != savedEntity) {
-                savedEntity = ws.deepCopy()
-                workspaceToUpdate = ws
+                workspaceToUpdate = ws.deepCopy()
             }
 
             val winEntities = ArrayList<WorkspaceEntities.Window>()
@@ -327,17 +326,17 @@ open class WindowRepository(val scope: CoroutineScope) {
             val hist = ArrayList<HistorySnap>(windows.size)
 
             windows.forEachIndexed { i, it ->
-                hist.add(HistorySnap(it.id, historyManager.getEntities(it.id)))
+                hist.add(HistorySnap(it.id, historyManager.getEntities(it.id).map { item ->
+                    item.copy(createdAt = Date(item.createdAt.time))
+                }))
                 val entity = it.entity.apply {
                     orderNumber = i
                 }
                 if (it.savedEntity != entity) {
-                    it.savedEntity = entity.deepCopy()
-                    winEntities.add(entity)
+                    winEntities.add(entity.deepCopy())
                 }
                 if (it.pageManager.isModified) {
-                    it.pageManager.savedEntity = it.pageManager.entity.deepCopy()
-                    pmEntities.add(it.pageManager.entity)
+                    pmEntities.add(it.pageManager.entity.deepCopy())
                 }
             }
             SaveSnap(workspaceToUpdate, winEntities, pmEntities, hist)
@@ -351,6 +350,16 @@ open class WindowRepository(val scope: CoroutineScope) {
         }
         dao.updateWindows(snap.windowEntities)
         dao.updatePageManagers(snap.pageManagers)
+
+        runOnMainBlocking {
+            snap.workspaceToUpdate?.let { savedEntity = it }
+            snap.windowEntities.forEach { entity ->
+                getWindow(entity.id)?.takeIf { it.entity == entity }?.savedEntity = entity
+            }
+            snap.pageManagers.forEach { entity ->
+                getWindow(entity.windowId)?.pageManager?.takeIf { it.entity == entity }?.savedEntity = entity
+            }
+        }
     }
 
     lateinit var savedEntity: WorkspaceEntities.Workspace

--- a/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
+++ b/app/src/main/java/net/bible/android/control/page/window/WindowRepository.kt
@@ -38,6 +38,7 @@ import net.bible.service.common.CommonUtils
 import net.bible.service.common.CommonUtils.getResourceString
 import net.bible.service.history.HistoryManager
 import org.crosswire.jsword.versification.BookName
+import runOnMainBlocking
 import javax.inject.Inject
 import javax.inject.Provider
 import kotlin.math.min
@@ -287,45 +288,69 @@ open class WindowRepository(val scope: CoroutineScope) {
         if(stopSpeak) speakControl.stop()
         workspaceSettings.speakSettings = SpeakSettings.currentSettings
         SpeakSettings.currentSettings?.save()
-        val ws = WorkspaceEntities.Workspace(
-            name = name,
-            contentsText = contentText,
-            id = id,
-            orderNumber = orderNumber,
-            textDisplaySettings = textDisplaySettings,
-            workspaceSettings = workspaceSettings,
-            unPinnedWeight = unPinnedWeight,
-            maximizedWindowId = maximizedWindowId,
-            primaryTargetLinksWindowId = primaryTargetLinksWindowId
-        )
-        if(ws != savedEntity) {
-            dao.updateWorkspace(ws)
-            savedEntity = ws.deepCopy()
-        }
 
         val historyManager = historyManagerProvider.get()
 
-        val windowEntities = windowList.mapIndexed { i, it ->
-            dao.updateHistoryItems(it.id, historyManager.getEntities(it.id))
-            val entity = it.entity.apply {
-                orderNumber = i
-            }
-            if(it.savedEntity != entity) {
-                it.savedEntity = entity.deepCopy()
-                entity
-            }
-            else null
-        }.filterNotNull()
+        data class HistorySnap(val windowId: IdType, val items: List<WorkspaceEntities.HistoryItem>)
+        data class SaveSnap(
+            val workspaceToUpdate: WorkspaceEntities.Workspace?,
+            val windowEntities: List<WorkspaceEntities.Window>,
+            val pageManagers: List<WorkspaceEntities.PageManager>,
+            val historySnaps: List<HistorySnap>,
+        )
 
-        val pageManagers = windowList.mapNotNull {
-            if (it.pageManager.isModified) {
-                it.pageManager.savedEntity = it.pageManager.entity.deepCopy()
-                it.pageManager.entity
-            } else null
+        // windowList (and history) is Main-thread-owned; saveIntoDb() can be called from
+        // background threads (e.g. cloud sync, db backup), so snapshot the in-memory state
+        // on Main before doing DAO writes on the caller's thread. See #3200.
+        val snap = runOnMainBlocking {
+            val windows = windowList.toList()
+            val ws = WorkspaceEntities.Workspace(
+                name = name,
+                contentsText = contentText,
+                id = id,
+                orderNumber = orderNumber,
+                textDisplaySettings = textDisplaySettings,
+                workspaceSettings = workspaceSettings,
+                unPinnedWeight = unPinnedWeight,
+                maximizedWindowId = maximizedWindowId,
+                primaryTargetLinksWindowId = primaryTargetLinksWindowId
+            )
+
+            var workspaceToUpdate: WorkspaceEntities.Workspace? = null
+            if (ws != savedEntity) {
+                savedEntity = ws.deepCopy()
+                workspaceToUpdate = ws
+            }
+
+            val winEntities = ArrayList<WorkspaceEntities.Window>()
+            val pmEntities = ArrayList<WorkspaceEntities.PageManager>()
+            val hist = ArrayList<HistorySnap>(windows.size)
+
+            windows.forEachIndexed { i, it ->
+                hist.add(HistorySnap(it.id, historyManager.getEntities(it.id)))
+                val entity = it.entity.apply {
+                    orderNumber = i
+                }
+                if (it.savedEntity != entity) {
+                    it.savedEntity = entity.deepCopy()
+                    winEntities.add(entity)
+                }
+                if (it.pageManager.isModified) {
+                    it.pageManager.savedEntity = it.pageManager.entity.deepCopy()
+                    pmEntities.add(it.pageManager.entity)
+                }
+            }
+            SaveSnap(workspaceToUpdate, winEntities, pmEntities, hist)
         }
 
-        dao.updateWindows(windowEntities)
-        dao.updatePageManagers(pageManagers)
+        snap.workspaceToUpdate?.let { 
+            dao.updateWorkspace(it)
+        }
+        for (historySnap in snap.historySnaps) {
+            dao.updateHistoryItems(historySnap.windowId, historySnap.items)
+        }
+        dao.updateWindows(snap.windowEntities)
+        dao.updatePageManagers(snap.pageManagers)
     }
 
     lateinit var savedEntity: WorkspaceEntities.Workspace

--- a/app/src/main/java/net/bible/android/database/WorkspaceEntities.kt
+++ b/app/src/main/java/net/bible/android/database/WorkspaceEntities.kt
@@ -104,7 +104,7 @@ class WorkspaceEntities {
             generalBookPage = generalBookPage?.copy(),
             mapPage = mapPage?.copy(),
             currentCategoryName = currentCategoryName,
-            textDisplaySettings = textDisplaySettings?.copy(),
+            textDisplaySettings = textDisplaySettings?.deepCopy(),
             jsState = jsState
         )
     }
@@ -220,6 +220,12 @@ class WorkspaceEntities {
         @ColumnInfo(defaultValue = "NULL") var showOrdinals: Boolean? = null,
         @ColumnInfo(defaultValue = "NULL") var showReadingProgress: Boolean? = null,
     ) {
+        fun deepCopy(): TextDisplaySettings = copy(
+            marginSize = marginSize?.copy(),
+            colors = colors?.copy(),
+            bookmarksHideLabels = bookmarksHideLabels?.toList(),
+        )
+
         enum class Types {
             FONTSIZE,
             FONTFAMILY,
@@ -568,7 +574,7 @@ class WorkspaceEntities {
             contentsText = contentsText,
             id = id,
             orderNumber = orderNumber,
-            textDisplaySettings = textDisplaySettings?.copy(),
+            textDisplaySettings = textDisplaySettings?.deepCopy(),
             workspaceSettings = workspaceSettings?.deepCopy(),
             unPinnedWeight = unPinnedWeight,
             maximizedWindowId = maximizedWindowId,
@@ -727,4 +733,3 @@ data class SettingsBundle (
     }
 
 }
-

--- a/app/src/main/java/net/bible/service/common/DebounceOperators.kt
+++ b/app/src/main/java/net/bible/service/common/DebounceOperators.kt
@@ -16,10 +16,13 @@
  */
 
 
+import android.os.Looper
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 // Debounce operators from https://gist.github.com/Terenfear/a84863be501d3399889455f391eeefe5
 
@@ -77,6 +80,22 @@ fun debounce(
         }
     }
 }
+
+/**
+ * Runs [block] on the Main thread, blocking the caller until it completes.
+ *
+ * If already on the Main thread, [block] runs immediately (no dispatch, no risk of
+ * deadlocking against Main). If called from a background thread, hops to Main and
+ * blocks until [block] finishes.
+ *
+ * Intended for state that is conceptually "owned" by the Main thread (e.g. in-memory
+ * window/history state) but occasionally needs to be read/snapshotted from background
+ * work such as cloud sync or database backup, without introducing per-field locking.
+ */
+inline fun <T> runOnMainBlocking(crossinline block: () -> T): T =
+    if (Looper.myLooper() == Looper.getMainLooper()) block()
+    else runBlocking(Dispatchers.Main.immediate) { block() }
+
 /**
  * Constructs a function that processes input data and passes the first data to [destinationFunction] and skips all new data for the next [skipMs].
  */


### PR DESCRIPTION
~Note: I have NOT tested this yet. I spent some time looking for the best solution and I think this is probably it. I will test and update this PR.~

Tested and seems to work. Though reproducing the bugs is probably not possible so easily anyway.

Fix #3200 and related CME. https://support.andbible.org/scp/tickets.php?id=3372

Replace scattered windows/history locks with main-thread confinement: window and history state remain Main-owned; saveIntoDb() snapshots that state via runOnMainBlocking before DAO writes on the caller's thread.

This fixes ConcurrentModificationException from cloud sync / backup calling saveIntoDb() on Dispatchers.IO without locking every mutator.