### PR TITLE
Fix #1911: Move reading plan import to plan selector

### DIFF
--- a/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/DailyReading.kt
@@ -38,7 +38,6 @@ import net.bible.android.control.readingplan.ReadingPlanControl
 import net.bible.android.control.readingplan.ReadingStatus
 import net.bible.android.view.activity.base.CustomTitlebarActivityBase
 import net.bible.android.view.activity.base.Dialogs
-import net.bible.android.view.activity.installzip.InstallZip
 import net.bible.android.view.activity.readingplan.actionbar.ReadingPlanActionBarManager
 import net.bible.service.common.CommonUtils
 import net.bible.service.db.ReadingPlansUpdatedViaSyncEvent
@@ -402,19 +401,7 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
 
             true
         }
-        R.id.import_reading_plan -> {
-            importPlanLauncher.launch("application/zip")
-            true
-        }
         else -> super.onOptionsItemSelected(item)
-    }
-
-    private val importPlanLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uriResult ->
-        Log.i(TAG, "Importing plan. Result uri is${if (uriResult != null) " not" else ""} null")
-        val uri = uriResult ?: return@registerForActivityResult
-
-        val intent = Intent(Intent.ACTION_VIEW, uri, this, InstallZip::class.java)
-        installZipLauncher.launch(intent)
     }
 
     val selectReadingPlan = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -439,11 +426,6 @@ class DailyReading : CustomTitlebarActivityBase(R.menu.reading_plan) {
 
             loadDailyReading(planCodeLoaded, planDay)
         }
-    }
-
-    val installZipLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        // TODO load imported plan if result is OK
-        //  still need to set up "InstallZip" to return reading plan fileName (code)
     }
 
     companion object {

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
@@ -28,6 +28,7 @@ import android.view.View
 import android.widget.AdapterView.AdapterContextMenuInfo
 import android.widget.ArrayAdapter
 import android.widget.ListView
+import androidx.activity.result.contract.ActivityResultContracts
 
 import net.bible.android.activity.R
 import net.bible.android.activity.databinding.ListBinding
@@ -35,6 +36,7 @@ import net.bible.android.control.event.ABEventBus
 import net.bible.android.control.readingplan.ReadingPlanControl
 import net.bible.android.view.activity.base.Dialogs
 import net.bible.android.view.activity.base.ListActivityBase
+import net.bible.android.view.activity.installzip.InstallZip
 import net.bible.service.db.ReadingPlansUpdatedViaSyncEvent
 import net.bible.service.readingplan.ReadingPlanInfoDto
 
@@ -44,7 +46,7 @@ import javax.inject.Inject
  *
  * @author Martin Denham [mjdenham at gmail dot com]
  */
-class ReadingPlanSelectorList : ListActivityBase() {
+class ReadingPlanSelectorList : ListActivityBase(R.menu.reading_plan_selector) {
 
     private lateinit var mReadingPlanList: List<ReadingPlanInfoDto>
     private lateinit var mPlanArrayAdapter: ArrayAdapter<ReadingPlanInfoDto>
@@ -128,12 +130,29 @@ class ReadingPlanSelectorList : ListActivityBase() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
+            R.id.import_reading_plan -> {
+                importPlanLauncher.launch("application/zip")
+                true
+            }
             android.R.id.home -> {
                 finish()
                 true
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    private val importPlanLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uriResult ->
+        Log.i(TAG, "Importing plan. Result uri is${if (uriResult != null) " not" else ""} null")
+        val uri = uriResult ?: return@registerForActivityResult
+
+        val intent = Intent(Intent.ACTION_VIEW, uri, this, InstallZip::class.java)
+        installZipLauncher.launch(intent)
+    }
+
+    private val installZipLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        // TODO load imported plan if result is OK
+        //  still need to set up "InstallZip" to return reading plan fileName (code)
     }
 
     companion object {

--- a/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
+++ b/app/src/main/java/net/bible/android/view/activity/readingplan/ReadingPlanSelectorList.kt
@@ -150,9 +150,11 @@ class ReadingPlanSelectorList : ListActivityBase(R.menu.reading_plan_selector) {
         installZipLauncher.launch(intent)
     }
 
-    private val installZipLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        // TODO load imported plan if result is OK
-        //  still need to set up "InstallZip" to return reading plan fileName (code)
+    private val installZipLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == RESULT_OK) {
+            // Refresh list so newly imported plans are immediately selectable
+            recreate()
+        }
     }
 
     companion object {

--- a/app/src/main/res/menu/reading_plan_selector.xml
+++ b/app/src/main/res/menu/reading_plan_selector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2022-2022 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
+  ~ Copyright (c) 2026 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
   ~
   ~ This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
   ~
@@ -16,18 +16,8 @@
   ~ If not, see http://www.gnu.org/licenses/.
   -->
 
-<!-- The main menu accessed via Menu key
- 
- @author Martin Denham [mjdenham at gmail dot com]
--->
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <group android:id="@+id/group1">
-		<item android:id="@+id/setCurrentDay"
-			  android:title="@string/set_current_day"/>
-		<item android:id="@+id/setStartDate"
-			  android:title="@string/rdg_plan_set_start_date"/>
-		<item android:id="@+id/reset"
-			  android:icon="@drawable/ic_baseline_undo_24"
-			  android:title="@string/reset_generic"/>
-	</group>
+    <item
+        android:id="@+id/import_reading_plan"
+        android:title="@string/import_reading_plan" />
 </menu>


### PR DESCRIPTION
## Summary

- Move the existing "Import reading plan" action from the Daily Reading screen to the main Reading Plan selection screen.
- Reuse the existing ZIP picker and InstallZip flow.
- Remove the import action from the Daily Reading menu.

Fixes #1911

## Scope

This PR does not change:

- the reading plan file format;
- database storage;
- import behavior;
- reading plan loading logic.

## Testing

- `.\gradlew.bat :app:compileStandardGithubDebugKotlin`
- Opened the Reading Plans list and launched the ZIP picker.
- Canceled the picker without errors.
- Not tested locally: importing a valid reading-plan ZIP because no suitable test ZIP was available. The existing ZIP picker and InstallZip flow were reused without changing import behavior.
- Confirmed existing plans can still be selected.
- Confirmed Import is no longer shown in the Daily Reading menu.

## Screenshots

### Before

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/50989aa3-a10e-40a1-af4c-3ac015e8a40d" />
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/74e8c7c0-a002-471c-9ce7-1f15efedecdb" />

### After

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/65fff18a-f82f-4ada-a028-73c4d0cca0aa" />
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/be319232-8490-442b-85c5-51e7147ebbe0" />
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/919139e2-6634-4ce0-b2ed-49e91949bc1d" />

