### PR TITLE
Fix backup zip entry names using platform separator on Windows

### DIFF
--- a/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
+++ b/app/src/main/java/net/bible/android/control/backup/BackupControl.kt
@@ -365,7 +365,8 @@ object BackupControl {
         val filePath = file.canonicalPath
         val dirPath = rootDir.canonicalPath
         assert(filePath.startsWith(dirPath))
-        return filePath.substring(dirPath.length + 1)
+        // Zip entry names use '/' on every platform (APPNOTE.TXT 4.4.17)
+        return filePath.substring(dirPath.length + 1).replace(File.separatorChar, '/')
     }
 
     private fun addFile(outFile: ZipOutputStream, rootDir: File, file: File) {
@@ -381,7 +382,7 @@ object BackupControl {
     private fun addModuleFile(outFile: ZipOutputStream, moduleFile: File) {
         FileInputStream(moduleFile).use { inFile ->
             BufferedInputStream(inFile).use { origin ->
-                val fileNameInsideZip = moduleFile.relativeTo(moduleDir).path
+                val fileNameInsideZip = moduleFile.relativeTo(moduleDir).invariantSeparatorsPath
                 val entry = ZipEntry(fileNameInsideZip)
                 outFile.putNextEntry(entry)
                 origin.copyTo(outFile)

--- a/app/src/test/java/net/bible/android/control/backup/ModuleBackupPackagingTest.kt
+++ b/app/src/test/java/net/bible/android/control/backup/ModuleBackupPackagingTest.kt
@@ -27,6 +27,8 @@ import org.crosswire.jsword.book.Book
 import org.crosswire.jsword.book.sword.NullBackend
 import org.crosswire.jsword.book.sword.SwordBook
 import org.crosswire.jsword.book.sword.SwordBookMetaData
+import net.bible.test.DatabaseResetter.resetDatabase
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -56,6 +58,11 @@ import java.util.zip.ZipFile
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestBibleApplication::class, sdk = [TEST_SDK])
 class ModuleBackupPackagingTest {
+    @After
+    fun tearDown() {
+        resetDatabase()
+    }
+
     private fun fakeBook(initials: String, conf: String): Book {
         val bmd = SwordBookMetaData(conf.toByteArray(), initials)
         return SwordBook(bmd, NullBackend())

--- a/app/src/test/java/net/bible/android/control/backup/ModuleBackupRoundTripTest.kt
+++ b/app/src/test/java/net/bible/android/control/backup/ModuleBackupRoundTripTest.kt
@@ -89,6 +89,9 @@ class ModuleBackupRoundTripTest {
             Books.installed().removeBook(b)
         }
         File(SharedConstants.modulesDir, BACKGROUND_IMAGE_DIR).deleteRecursively()
+        // Room connections are also process-global under Robolectric — same reset as
+        // PromptCsvUtilsTest, else later tests hit stale connection pointers.
+        net.bible.test.DatabaseResetter.resetDatabase()
     }
 
     /**


### PR DESCRIPTION
## Problem

Module backup zips created on Windows contain entry names with backslashes (e.g. `mybible\Module.sqlite3`). The ZIP specification (APPNOTE.TXT 4.4.17) requires forward slashes regardless of platform, so such backups fail to restore correctly cross-platform. The bug is invisible on Linux CI because `File.separatorChar` is already `/` there.

## Fix

Both places in `BackupControl` that build zip entry names from filesystem paths now emit invariant separators:

- `relativeFileName()`: replace `File.separatorChar` with `/` in the substring result
- `addModuleFile()`: use Kotlin's `relativeTo(...).invariantSeparatorsPath`

## Tests

`ModuleBackupPackagingTest.myBibleModulePackagesSqliteFile` reproduces the bug on Windows (red before, green after). Additionally, both module backup test classes now reset the database in `@After` (same pattern as `PromptCsvUtilsTest`), fixing "Illegal connection pointer" failures from stale Robolectric SQLite connections when these classes run after other test classes on the same JVM.

All six tests in the two classes pass on Windows after this change:

```
./gradlew testStandardGoogleplayDebugUnitTest --tests "*ModuleBackupPackagingTest*" --tests "*ModuleBackupRoundTripTest*"
```
