### PR TITLE
Make bookmark delete icon white when selected

### DIFF
--- a/app/src/main/res/drawable/ic_delete_24dp.xml
+++ b/app/src/main/res/drawable/ic_delete_24dp.xml
@@ -18,6 +18,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
         android:width="24dp"
         android:height="24dp"
+        android:tint="@color/white"
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path


### PR DESCRIPTION
Tint ic_delete_24dp white so it matches other action-bar icons instead of looking disabled. This is the same style that the icon beside it, ic_label_24dp has.

<img width="424" height="168" alt="image" src="https://github.com/user-attachments/assets/4b25780a-b991-4bc4-ac41-f3193bdc2178" />

Address support ticket: https://support.andbible.org/scp/tickets.php?id=3385