### PR TITLE
Add color theme presets

### DIFF
--- a/app/bibleview-js/src/__tests__/colors.spec.js
+++ b/app/bibleview-js/src/__tests__/colors.spec.js
@@ -17,6 +17,7 @@
 
 
 import {adjustedColor, colorLightness, mixColors} from "@/utils";
+import {resolveThemeAccentColors} from "@/composables/theme-colors";
 import Color from "color";
 import { describe, it, expect } from 'vitest'
 
@@ -44,4 +45,32 @@ describe("myMixColors test", () => {
     it("Test 1 ", () => expect(Color("#FCE6EA").lighten(0.4).hex()).toEqual("#FFFFFF"));
     it("Test 2 ", () => expect(col.lighten(0.6).hex()).toEqual("#FFFFFF"));
     it("Adjusted color 1 ", () => expect(adjustedColor(-1282938, -0.6).hex()).toEqual("#FEF5F7"));
+});
+
+describe("resolveThemeAccentColors", () => {
+    const themed = {
+        dayLinkColor: 0x076678, dayVerseNumberColor: 0x7c6f64, dayHeadingColor: 0xb57614,
+        nightLinkColor: 0x83a598, nightVerseNumberColor: 0xa89984, nightHeadingColor: 0xfabd2f,
+    };
+    it("day mode returns day colors", () => {
+        const r = resolveThemeAccentColors(themed, {nightMode: false, monochromeMode: false});
+        expect(Color(r.linkColor).hex()).toEqual("#076678");
+        expect(Color(r.headingColor).hex()).toEqual("#B57614");
+    });
+    it("night mode returns night colors", () => {
+        const r = resolveThemeAccentColors(themed, {nightMode: true, monochromeMode: false});
+        expect(Color(r.linkColor).hex()).toEqual("#83A598");
+    });
+    it("monochrome suppresses all accents", () => {
+        const r = resolveThemeAccentColors(themed, {nightMode: false, monochromeMode: true});
+        expect(r.linkColor).toBeNull();
+        expect(r.verseNumberColor).toBeNull();
+        expect(r.headingColor).toBeNull();
+    });
+    it("unset fields return null (fallback to defaults)", () => {
+        const r = resolveThemeAccentColors({}, {nightMode: false, monochromeMode: false});
+        expect(r.linkColor).toBeNull();
+        expect(r.verseNumberColor).toBeNull();
+        expect(r.headingColor).toBeNull();
+    });
 });

--- a/app/bibleview-js/src/components/BibleView.vue
+++ b/app/bibleview-js/src/components/BibleView.vue
@@ -685,11 +685,10 @@ $colorEinkAccentNight: rgba(196, 196, 255, 0.8);
 }
 
 a {
-  color: blue;
-
-  .night & {
-    color: #7b7bff;
-  }
+  // Route all in-content links (incl. OSIS cross-references) through --link-color so color-theme
+  // presets reach them. common.scss defines --link-color per day/night/monochrome, so the default
+  // and e-ink behaviour is preserved when no preset overrides it.
+  color: var(--link-color);
 }
 
 .bookmark-marker {

--- a/app/bibleview-js/src/components/BibleView.vue
+++ b/app/bibleview-js/src/components/BibleView.vue
@@ -151,6 +151,7 @@ import {useVerseNotifier} from "@/composables/verse-notifier";
 import {useAddonFonts} from "@/composables/addon-fonts";
 import {useFontAwesome} from "@/composables/fontawesome";
 import {black, useConfig, white} from "@/composables/config";
+import {resolveThemeAccentColors} from "@/composables/theme-colors";
 import {calcHelperLinePositions, calcMaxScrollY, calcPageScrollDistance, calcRelativePageNumbers} from "@/composables/page-scroll";
 import {useOrdinalHighlight} from "@/composables/ordinal-highlight";
 import {useModal} from "@/composables/modal";
@@ -414,6 +415,15 @@ const topStyle = computed(() => {
             textColor.fade(0.5).hsl().string();
     }
 
+    const accent = resolveThemeAccentColors(config.colors, {
+        nightMode: appSettings.nightMode,
+        monochromeMode: appSettings.monochromeMode,
+    });
+    // Theme verse-number color overrides the derived fade when present.
+    const finalVerseNumberColor = accent.verseNumberColor ?? verseNumberColor;
+    const linkVar = accent.linkColor ? `--link-color: ${accent.linkColor};` : "";
+    const headingVar = accent.headingColor ? `--heading-color: ${accent.headingColor};` : "";
+
     return `
           --bottom-offset: ${appSettings.bottomOffset}px;
           --top-offset: ${appSettings.topOffset}px;
@@ -423,8 +433,10 @@ const topStyle = computed(() => {
           --text-color-h: ${textColor.hsl().array()[0]};
           --text-color-s: ${textColor.hsl().array()[1]}%;
           --text-color-l: ${textColor.hsl().array()[2]}%;
-          --verse-number-color: ${verseNumberColor};
+          --verse-number-color: ${finalVerseNumberColor};
           --background-color: ${backgroundColor.hsl().string()};
+          ${linkVar}
+          ${headingVar}
           `;
 });
 

--- a/app/bibleview-js/src/components/OSIS/Title.vue
+++ b/app/bibleview-js/src/components/OSIS/Title.vue
@@ -74,6 +74,10 @@ function scrollToTitle() {
 </script>
 
 <style lang="scss">
+.titleStyle {
+  color: var(--heading-color, inherit);
+}
+
 .listStyle .titleStyle {
   margin-inline-start: -1em;
 }

--- a/app/bibleview-js/src/composables/config.ts
+++ b/app/bibleview-js/src/composables/config.ts
@@ -82,6 +82,13 @@ export type Config = {
         nightBackgroundImage: string | null,
         dayBackgroundImageOpacity: number,
         nightBackgroundImageOpacity: number,
+        dayLinkColor?: number | null,
+        nightLinkColor?: number | null,
+        dayVerseNumberColor?: number | null,
+        nightVerseNumberColor?: number | null,
+        dayHeadingColor?: number | null,
+        nightHeadingColor?: number | null,
+        themeName?: string | null,
     },
 
     hyphenation: boolean,

--- a/app/bibleview-js/src/composables/theme-colors.ts
+++ b/app/bibleview-js/src/composables/theme-colors.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Martin Denham, Tuomas Airaksinen and the AndBible contributors.
+ *
+ * This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+ *
+ * AndBible is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with AndBible.
+ * If not, see http://www.gnu.org/licenses/.
+ */
+
+import Color from "color";
+
+interface ThemeColorFields {
+    dayLinkColor?: number | null;
+    nightLinkColor?: number | null;
+    dayVerseNumberColor?: number | null;
+    nightVerseNumberColor?: number | null;
+    dayHeadingColor?: number | null;
+    nightHeadingColor?: number | null;
+}
+
+interface ModeFlags { nightMode: boolean; monochromeMode: boolean; }
+
+export interface ResolvedAccentColors {
+    linkColor: string | null;
+    verseNumberColor: string | null;
+    headingColor: string | null;
+}
+
+function css(value: number | null | undefined): string | null {
+    return (value === null || value === undefined) ? null : Color(value).hsl().string();
+}
+
+/**
+ * Resolves theme accent colors for the active day/night mode. Returns null for any
+ * slot that is unset or when monochrome (e-ink) mode is active, so the caller can
+ * omit the CSS variable and let existing defaults/derivations apply.
+ */
+export function resolveThemeAccentColors(
+    colors: ThemeColorFields,
+    {nightMode, monochromeMode}: ModeFlags,
+): ResolvedAccentColors {
+    if (monochromeMode) return {linkColor: null, verseNumberColor: null, headingColor: null};
+    return {
+        linkColor: css(nightMode ? colors.nightLinkColor : colors.dayLinkColor),
+        verseNumberColor: css(nightMode ? colors.nightVerseNumberColor : colors.dayVerseNumberColor),
+        headingColor: css(nightMode ? colors.nightHeadingColor : colors.dayHeadingColor),
+    };
+}

--- a/app/schemas/net.bible.android.database.WorkspaceDatabase/25.json
+++ b/app/schemas/net.bible.android.database.WorkspaceDatabase/25.json
@@ -1,0 +1,1622 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 25,
+    "identityHash": "8f2172100503577bd9903cbfdf541cb4",
+    "entities": [
+      {
+        "tableName": "Workspace",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `contentsText` TEXT, `id` BLOB NOT NULL, `orderNumber` INTEGER NOT NULL DEFAULT 0, `unPinnedWeight` REAL DEFAULT NULL, `maximizedWindowId` BLOB, `primaryTargetLinksWindowId` BLOB DEFAULT NULL, `text_display_settings_strongsMode` INTEGER DEFAULT NULL, `text_display_settings_showMorphology` INTEGER DEFAULT NULL, `text_display_settings_showFootNotes` INTEGER DEFAULT NULL, `text_display_settings_showFootNotesInline` INTEGER DEFAULT NULL, `text_display_settings_expandXrefs` INTEGER DEFAULT NULL, `text_display_settings_showXrefs` INTEGER DEFAULT NULL, `text_display_settings_showRedLetters` INTEGER DEFAULT NULL, `text_display_settings_showSectionTitles` INTEGER DEFAULT NULL, `text_display_settings_showVerseNumbers` INTEGER DEFAULT NULL, `text_display_settings_showVersePerLine` INTEGER DEFAULT NULL, `text_display_settings_showBookmarks` INTEGER DEFAULT NULL, `text_display_settings_showMyNotes` INTEGER DEFAULT NULL, `text_display_settings_justifyText` INTEGER DEFAULT NULL, `text_display_settings_hyphenation` INTEGER DEFAULT NULL, `text_display_settings_topMargin` INTEGER DEFAULT NULL, `text_display_settings_fontSize` INTEGER DEFAULT NULL, `text_display_settings_fontFamily` TEXT DEFAULT NULL, `text_display_settings_lineSpacing` INTEGER DEFAULT NULL, `text_display_settings_bookmarksHideLabels` TEXT DEFAULT NULL, `text_display_settings_showPageNumber` INTEGER DEFAULT NULL, `text_display_settings_infiniteScroll` INTEGER DEFAULT NULL, `text_display_settings_nonStrongsWordItalic` INTEGER DEFAULT NULL, `text_display_settings_showMarkAsReadButton` INTEGER DEFAULT NULL, `text_display_settings_showTitleScrollButton` INTEGER DEFAULT NULL, `text_display_settings_showMemorizationIndicators` INTEGER DEFAULT NULL, `text_display_settings_autoTrackReading` INTEGER DEFAULT NULL, `text_display_settings_showAiDocMarkers` INTEGER DEFAULT NULL, `text_display_settings_pageScrollAmount` INTEGER DEFAULT NULL, `text_display_settings_scrollHelperLines` INTEGER DEFAULT NULL, `text_display_settings_scrollHelperLineStyle` INTEGER DEFAULT NULL, `text_display_settings_showPageButtons` INTEGER DEFAULT NULL, `text_display_settings_showOrdinals` INTEGER DEFAULT NULL, `text_display_settings_showReadingProgress` INTEGER DEFAULT NULL, `text_display_settings_margin_size_marginLeft` INTEGER DEFAULT NULL, `text_display_settings_margin_size_marginRight` INTEGER DEFAULT NULL, `text_display_settings_margin_size_maxWidth` INTEGER DEFAULT NULL, `text_display_settings_colors_dayTextColor` INTEGER DEFAULT NULL, `text_display_settings_colors_dayBackground` INTEGER DEFAULT NULL, `text_display_settings_colors_dayNoise` INTEGER DEFAULT NULL, `text_display_settings_colors_nightTextColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightBackground` INTEGER DEFAULT NULL, `text_display_settings_colors_nightNoise` INTEGER DEFAULT NULL, `text_display_settings_colors_dayBackgroundImage` TEXT DEFAULT NULL, `text_display_settings_colors_nightBackgroundImage` TEXT DEFAULT NULL, `text_display_settings_colors_dayBackgroundImageOpacity` INTEGER DEFAULT NULL, `text_display_settings_colors_nightBackgroundImageOpacity` INTEGER DEFAULT NULL, `text_display_settings_colors_dayLinkColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightLinkColor` INTEGER DEFAULT NULL, `text_display_settings_colors_dayVerseNumberColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightVerseNumberColor` INTEGER DEFAULT NULL, `text_display_settings_colors_dayHeadingColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightHeadingColor` INTEGER DEFAULT NULL, `text_display_settings_colors_themeName` TEXT DEFAULT NULL, `workspace_settings_enableTiltToScroll` INTEGER DEFAULT 0, `workspace_settings_enableReverseSplitMode` INTEGER DEFAULT 0, `workspace_settings_autoPin` INTEGER DEFAULT 1, `workspace_settings_speakSettings` TEXT DEFAULT NULL, `workspace_settings_recentLabels` TEXT DEFAULT NULL, `workspace_settings_autoAssignLabels` TEXT DEFAULT NULL, `workspace_settings_autoAssignPrimaryLabel` BLOB DEFAULT NULL, `workspace_settings_studyPadCursors` TEXT DEFAULT NULL, `workspace_settings_hideCompareDocuments` TEXT DEFAULT NULL, `workspace_settings_limitAmbiguousModalSize` INTEGER DEFAULT 0, `workspace_settings_workspaceColor` INTEGER DEFAULT NULL, `workspace_settings_restoreButtonsVisible` INTEGER DEFAULT 1, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentsText",
+            "columnName": "contentsText",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "unPinnedWeight",
+            "columnName": "unPinnedWeight",
+            "affinity": "REAL",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "maximizedWindowId",
+            "columnName": "maximizedWindowId",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "primaryTargetLinksWindowId",
+            "columnName": "primaryTargetLinksWindowId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.strongsMode",
+            "columnName": "text_display_settings_strongsMode",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMorphology",
+            "columnName": "text_display_settings_showMorphology",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showFootNotes",
+            "columnName": "text_display_settings_showFootNotes",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showFootNotesInline",
+            "columnName": "text_display_settings_showFootNotesInline",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.expandXrefs",
+            "columnName": "text_display_settings_expandXrefs",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showXrefs",
+            "columnName": "text_display_settings_showXrefs",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showRedLetters",
+            "columnName": "text_display_settings_showRedLetters",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showSectionTitles",
+            "columnName": "text_display_settings_showSectionTitles",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showVerseNumbers",
+            "columnName": "text_display_settings_showVerseNumbers",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showVersePerLine",
+            "columnName": "text_display_settings_showVersePerLine",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showBookmarks",
+            "columnName": "text_display_settings_showBookmarks",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMyNotes",
+            "columnName": "text_display_settings_showMyNotes",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.justifyText",
+            "columnName": "text_display_settings_justifyText",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.hyphenation",
+            "columnName": "text_display_settings_hyphenation",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.topMargin",
+            "columnName": "text_display_settings_topMargin",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.fontSize",
+            "columnName": "text_display_settings_fontSize",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.fontFamily",
+            "columnName": "text_display_settings_fontFamily",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.lineSpacing",
+            "columnName": "text_display_settings_lineSpacing",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.bookmarksHideLabels",
+            "columnName": "text_display_settings_bookmarksHideLabels",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showPageNumber",
+            "columnName": "text_display_settings_showPageNumber",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.infiniteScroll",
+            "columnName": "text_display_settings_infiniteScroll",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.nonStrongsWordItalic",
+            "columnName": "text_display_settings_nonStrongsWordItalic",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMarkAsReadButton",
+            "columnName": "text_display_settings_showMarkAsReadButton",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showTitleScrollButton",
+            "columnName": "text_display_settings_showTitleScrollButton",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMemorizationIndicators",
+            "columnName": "text_display_settings_showMemorizationIndicators",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.autoTrackReading",
+            "columnName": "text_display_settings_autoTrackReading",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showAiDocMarkers",
+            "columnName": "text_display_settings_showAiDocMarkers",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.pageScrollAmount",
+            "columnName": "text_display_settings_pageScrollAmount",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.scrollHelperLines",
+            "columnName": "text_display_settings_scrollHelperLines",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.scrollHelperLineStyle",
+            "columnName": "text_display_settings_scrollHelperLineStyle",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showPageButtons",
+            "columnName": "text_display_settings_showPageButtons",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showOrdinals",
+            "columnName": "text_display_settings_showOrdinals",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showReadingProgress",
+            "columnName": "text_display_settings_showReadingProgress",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.marginSize.marginLeft",
+            "columnName": "text_display_settings_margin_size_marginLeft",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.marginSize.marginRight",
+            "columnName": "text_display_settings_margin_size_marginRight",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.marginSize.maxWidth",
+            "columnName": "text_display_settings_margin_size_maxWidth",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayTextColor",
+            "columnName": "text_display_settings_colors_dayTextColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayBackground",
+            "columnName": "text_display_settings_colors_dayBackground",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayNoise",
+            "columnName": "text_display_settings_colors_dayNoise",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightTextColor",
+            "columnName": "text_display_settings_colors_nightTextColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightBackground",
+            "columnName": "text_display_settings_colors_nightBackground",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightNoise",
+            "columnName": "text_display_settings_colors_nightNoise",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayBackgroundImage",
+            "columnName": "text_display_settings_colors_dayBackgroundImage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightBackgroundImage",
+            "columnName": "text_display_settings_colors_nightBackgroundImage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayBackgroundImageOpacity",
+            "columnName": "text_display_settings_colors_dayBackgroundImageOpacity",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightBackgroundImageOpacity",
+            "columnName": "text_display_settings_colors_nightBackgroundImageOpacity",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayLinkColor",
+            "columnName": "text_display_settings_colors_dayLinkColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightLinkColor",
+            "columnName": "text_display_settings_colors_nightLinkColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayVerseNumberColor",
+            "columnName": "text_display_settings_colors_dayVerseNumberColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightVerseNumberColor",
+            "columnName": "text_display_settings_colors_nightVerseNumberColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayHeadingColor",
+            "columnName": "text_display_settings_colors_dayHeadingColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightHeadingColor",
+            "columnName": "text_display_settings_colors_nightHeadingColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.themeName",
+            "columnName": "text_display_settings_colors_themeName",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "workspaceSettings.enableTiltToScroll",
+            "columnName": "workspace_settings_enableTiltToScroll",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "workspaceSettings.enableReverseSplitMode",
+            "columnName": "workspace_settings_enableReverseSplitMode",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "workspaceSettings.autoPin",
+            "columnName": "workspace_settings_autoPin",
+            "affinity": "INTEGER",
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "workspaceSettings.speakSettings",
+            "columnName": "workspace_settings_speakSettings",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "workspaceSettings.recentLabels",
+            "columnName": "workspace_settings_recentLabels",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "workspaceSettings.autoAssignLabels",
+            "columnName": "workspace_settings_autoAssignLabels",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "workspaceSettings.autoAssignPrimaryLabel",
+            "columnName": "workspace_settings_autoAssignPrimaryLabel",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "workspaceSettings.studyPadCursors",
+            "columnName": "workspace_settings_studyPadCursors",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "workspaceSettings.hideCompareDocuments",
+            "columnName": "workspace_settings_hideCompareDocuments",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "workspaceSettings.limitAmbiguousModalSize",
+            "columnName": "workspace_settings_limitAmbiguousModalSize",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "workspaceSettings.workspaceColor",
+            "columnName": "workspace_settings_workspaceColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "workspaceSettings.restoreButtonsVisible",
+            "columnName": "workspace_settings_restoreButtonsVisible",
+            "affinity": "INTEGER",
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "Window",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`workspaceId` BLOB NOT NULL, `isSynchronized` INTEGER NOT NULL, `isPinMode` INTEGER NOT NULL, `isLinksWindow` INTEGER NOT NULL, `id` BLOB NOT NULL, `orderNumber` INTEGER NOT NULL, `targetLinksWindowId` BLOB DEFAULT NULL, `syncGroup` INTEGER NOT NULL DEFAULT 0, `window_layout_state` TEXT NOT NULL, `window_layout_weight` REAL NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`workspaceId`) REFERENCES `Workspace`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "workspaceId",
+            "columnName": "workspaceId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynchronized",
+            "columnName": "isSynchronized",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinMode",
+            "columnName": "isPinMode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLinksWindow",
+            "columnName": "isLinksWindow",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderNumber",
+            "columnName": "orderNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetLinksWindowId",
+            "columnName": "targetLinksWindowId",
+            "affinity": "BLOB",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "syncGroup",
+            "columnName": "syncGroup",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "windowLayout.state",
+            "columnName": "window_layout_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "windowLayout.weight",
+            "columnName": "window_layout_weight",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Window_workspaceId",
+            "unique": false,
+            "columnNames": [
+              "workspaceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Window_workspaceId` ON `${TABLE_NAME}` (`workspaceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Workspace",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "workspaceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "HistoryItem",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`windowId` BLOB NOT NULL, `createdAt` INTEGER NOT NULL, `document` TEXT NOT NULL, `key` TEXT NOT NULL, `anchorOrdinal` INTEGER DEFAULT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`windowId`) REFERENCES `Window`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "windowId",
+            "columnName": "windowId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "document",
+            "columnName": "document",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anchorOrdinal",
+            "columnName": "anchorOrdinal",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_HistoryItem_windowId",
+            "unique": false,
+            "columnNames": [
+              "windowId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_HistoryItem_windowId` ON `${TABLE_NAME}` (`windowId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Window",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "windowId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PageManager",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`windowId` BLOB NOT NULL, `currentCategoryName` TEXT NOT NULL, `jsState` TEXT, `bible_document` TEXT, `bible_verse_versification` TEXT NOT NULL, `bible_verse_bibleBook` INTEGER NOT NULL, `bible_verse_chapterNo` INTEGER NOT NULL, `bible_verse_verseNo` INTEGER NOT NULL, `commentary_document` TEXT, `commentary_anchorOrdinal` INTEGER DEFAULT NULL, `commentary_sourceBookAndKey` TEXT DEFAULT NULL, `dictionary_document` TEXT, `dictionary_key` TEXT, `dictionary_anchorOrdinal` INTEGER DEFAULT NULL, `general_book_document` TEXT, `general_book_key` TEXT, `general_book_anchorOrdinal` INTEGER DEFAULT NULL, `map_document` TEXT, `map_key` TEXT, `map_anchorOrdinal` INTEGER DEFAULT NULL, `text_display_settings_strongsMode` INTEGER DEFAULT NULL, `text_display_settings_showMorphology` INTEGER DEFAULT NULL, `text_display_settings_showFootNotes` INTEGER DEFAULT NULL, `text_display_settings_showFootNotesInline` INTEGER DEFAULT NULL, `text_display_settings_expandXrefs` INTEGER DEFAULT NULL, `text_display_settings_showXrefs` INTEGER DEFAULT NULL, `text_display_settings_showRedLetters` INTEGER DEFAULT NULL, `text_display_settings_showSectionTitles` INTEGER DEFAULT NULL, `text_display_settings_showVerseNumbers` INTEGER DEFAULT NULL, `text_display_settings_showVersePerLine` INTEGER DEFAULT NULL, `text_display_settings_showBookmarks` INTEGER DEFAULT NULL, `text_display_settings_showMyNotes` INTEGER DEFAULT NULL, `text_display_settings_justifyText` INTEGER DEFAULT NULL, `text_display_settings_hyphenation` INTEGER DEFAULT NULL, `text_display_settings_topMargin` INTEGER DEFAULT NULL, `text_display_settings_fontSize` INTEGER DEFAULT NULL, `text_display_settings_fontFamily` TEXT DEFAULT NULL, `text_display_settings_lineSpacing` INTEGER DEFAULT NULL, `text_display_settings_bookmarksHideLabels` TEXT DEFAULT NULL, `text_display_settings_showPageNumber` INTEGER DEFAULT NULL, `text_display_settings_infiniteScroll` INTEGER DEFAULT NULL, `text_display_settings_nonStrongsWordItalic` INTEGER DEFAULT NULL, `text_display_settings_showMarkAsReadButton` INTEGER DEFAULT NULL, `text_display_settings_showTitleScrollButton` INTEGER DEFAULT NULL, `text_display_settings_showMemorizationIndicators` INTEGER DEFAULT NULL, `text_display_settings_autoTrackReading` INTEGER DEFAULT NULL, `text_display_settings_showAiDocMarkers` INTEGER DEFAULT NULL, `text_display_settings_pageScrollAmount` INTEGER DEFAULT NULL, `text_display_settings_scrollHelperLines` INTEGER DEFAULT NULL, `text_display_settings_scrollHelperLineStyle` INTEGER DEFAULT NULL, `text_display_settings_showPageButtons` INTEGER DEFAULT NULL, `text_display_settings_showOrdinals` INTEGER DEFAULT NULL, `text_display_settings_showReadingProgress` INTEGER DEFAULT NULL, `text_display_settings_margin_size_marginLeft` INTEGER DEFAULT NULL, `text_display_settings_margin_size_marginRight` INTEGER DEFAULT NULL, `text_display_settings_margin_size_maxWidth` INTEGER DEFAULT NULL, `text_display_settings_colors_dayTextColor` INTEGER DEFAULT NULL, `text_display_settings_colors_dayBackground` INTEGER DEFAULT NULL, `text_display_settings_colors_dayNoise` INTEGER DEFAULT NULL, `text_display_settings_colors_nightTextColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightBackground` INTEGER DEFAULT NULL, `text_display_settings_colors_nightNoise` INTEGER DEFAULT NULL, `text_display_settings_colors_dayBackgroundImage` TEXT DEFAULT NULL, `text_display_settings_colors_nightBackgroundImage` TEXT DEFAULT NULL, `text_display_settings_colors_dayBackgroundImageOpacity` INTEGER DEFAULT NULL, `text_display_settings_colors_nightBackgroundImageOpacity` INTEGER DEFAULT NULL, `text_display_settings_colors_dayLinkColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightLinkColor` INTEGER DEFAULT NULL, `text_display_settings_colors_dayVerseNumberColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightVerseNumberColor` INTEGER DEFAULT NULL, `text_display_settings_colors_dayHeadingColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightHeadingColor` INTEGER DEFAULT NULL, `text_display_settings_colors_themeName` TEXT DEFAULT NULL, PRIMARY KEY(`windowId`), FOREIGN KEY(`windowId`) REFERENCES `Window`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "windowId",
+            "columnName": "windowId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentCategoryName",
+            "columnName": "currentCategoryName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jsState",
+            "columnName": "jsState",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "biblePage.document",
+            "columnName": "bible_document",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "biblePage.verse.versification",
+            "columnName": "bible_verse_versification",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "biblePage.verse.bibleBook",
+            "columnName": "bible_verse_bibleBook",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "biblePage.verse.chapterNo",
+            "columnName": "bible_verse_chapterNo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "biblePage.verse.verseNo",
+            "columnName": "bible_verse_verseNo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentaryPage.document",
+            "columnName": "commentary_document",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "commentaryPage.anchorOrdinal",
+            "columnName": "commentary_anchorOrdinal",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "commentaryPage.sourceBookAndKey",
+            "columnName": "commentary_sourceBookAndKey",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "dictionaryPage.document",
+            "columnName": "dictionary_document",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dictionaryPage.key",
+            "columnName": "dictionary_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dictionaryPage.anchorOrdinal",
+            "columnName": "dictionary_anchorOrdinal",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "generalBookPage.document",
+            "columnName": "general_book_document",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "generalBookPage.key",
+            "columnName": "general_book_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "generalBookPage.anchorOrdinal",
+            "columnName": "general_book_anchorOrdinal",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "mapPage.document",
+            "columnName": "map_document",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mapPage.key",
+            "columnName": "map_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mapPage.anchorOrdinal",
+            "columnName": "map_anchorOrdinal",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.strongsMode",
+            "columnName": "text_display_settings_strongsMode",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMorphology",
+            "columnName": "text_display_settings_showMorphology",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showFootNotes",
+            "columnName": "text_display_settings_showFootNotes",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showFootNotesInline",
+            "columnName": "text_display_settings_showFootNotesInline",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.expandXrefs",
+            "columnName": "text_display_settings_expandXrefs",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showXrefs",
+            "columnName": "text_display_settings_showXrefs",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showRedLetters",
+            "columnName": "text_display_settings_showRedLetters",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showSectionTitles",
+            "columnName": "text_display_settings_showSectionTitles",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showVerseNumbers",
+            "columnName": "text_display_settings_showVerseNumbers",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showVersePerLine",
+            "columnName": "text_display_settings_showVersePerLine",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showBookmarks",
+            "columnName": "text_display_settings_showBookmarks",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMyNotes",
+            "columnName": "text_display_settings_showMyNotes",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.justifyText",
+            "columnName": "text_display_settings_justifyText",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.hyphenation",
+            "columnName": "text_display_settings_hyphenation",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.topMargin",
+            "columnName": "text_display_settings_topMargin",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.fontSize",
+            "columnName": "text_display_settings_fontSize",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.fontFamily",
+            "columnName": "text_display_settings_fontFamily",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.lineSpacing",
+            "columnName": "text_display_settings_lineSpacing",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.bookmarksHideLabels",
+            "columnName": "text_display_settings_bookmarksHideLabels",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showPageNumber",
+            "columnName": "text_display_settings_showPageNumber",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.infiniteScroll",
+            "columnName": "text_display_settings_infiniteScroll",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.nonStrongsWordItalic",
+            "columnName": "text_display_settings_nonStrongsWordItalic",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMarkAsReadButton",
+            "columnName": "text_display_settings_showMarkAsReadButton",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showTitleScrollButton",
+            "columnName": "text_display_settings_showTitleScrollButton",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMemorizationIndicators",
+            "columnName": "text_display_settings_showMemorizationIndicators",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.autoTrackReading",
+            "columnName": "text_display_settings_autoTrackReading",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showAiDocMarkers",
+            "columnName": "text_display_settings_showAiDocMarkers",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.pageScrollAmount",
+            "columnName": "text_display_settings_pageScrollAmount",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.scrollHelperLines",
+            "columnName": "text_display_settings_scrollHelperLines",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.scrollHelperLineStyle",
+            "columnName": "text_display_settings_scrollHelperLineStyle",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showPageButtons",
+            "columnName": "text_display_settings_showPageButtons",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showOrdinals",
+            "columnName": "text_display_settings_showOrdinals",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showReadingProgress",
+            "columnName": "text_display_settings_showReadingProgress",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.marginSize.marginLeft",
+            "columnName": "text_display_settings_margin_size_marginLeft",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.marginSize.marginRight",
+            "columnName": "text_display_settings_margin_size_marginRight",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.marginSize.maxWidth",
+            "columnName": "text_display_settings_margin_size_maxWidth",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayTextColor",
+            "columnName": "text_display_settings_colors_dayTextColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayBackground",
+            "columnName": "text_display_settings_colors_dayBackground",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayNoise",
+            "columnName": "text_display_settings_colors_dayNoise",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightTextColor",
+            "columnName": "text_display_settings_colors_nightTextColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightBackground",
+            "columnName": "text_display_settings_colors_nightBackground",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightNoise",
+            "columnName": "text_display_settings_colors_nightNoise",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayBackgroundImage",
+            "columnName": "text_display_settings_colors_dayBackgroundImage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightBackgroundImage",
+            "columnName": "text_display_settings_colors_nightBackgroundImage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayBackgroundImageOpacity",
+            "columnName": "text_display_settings_colors_dayBackgroundImageOpacity",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightBackgroundImageOpacity",
+            "columnName": "text_display_settings_colors_nightBackgroundImageOpacity",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayLinkColor",
+            "columnName": "text_display_settings_colors_dayLinkColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightLinkColor",
+            "columnName": "text_display_settings_colors_nightLinkColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayVerseNumberColor",
+            "columnName": "text_display_settings_colors_dayVerseNumberColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightVerseNumberColor",
+            "columnName": "text_display_settings_colors_nightVerseNumberColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayHeadingColor",
+            "columnName": "text_display_settings_colors_dayHeadingColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightHeadingColor",
+            "columnName": "text_display_settings_colors_nightHeadingColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.themeName",
+            "columnName": "text_display_settings_colors_themeName",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "windowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PageManager_windowId",
+            "unique": true,
+            "columnNames": [
+              "windowId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_PageManager_windowId` ON `${TABLE_NAME}` (`windowId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Window",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "windowId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "WorkspaceLabelOverride",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`workspaceId` BLOB NOT NULL, `labelId` BLOB NOT NULL, `overrideMode` INTEGER DEFAULT NULL, PRIMARY KEY(`workspaceId`, `labelId`), FOREIGN KEY(`workspaceId`) REFERENCES `Workspace`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "workspaceId",
+            "columnName": "workspaceId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "labelId",
+            "columnName": "labelId",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideMode",
+            "columnName": "overrideMode",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "workspaceId",
+            "labelId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_WorkspaceLabelOverride_workspaceId",
+            "unique": false,
+            "columnNames": [
+              "workspaceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_WorkspaceLabelOverride_workspaceId` ON `${TABLE_NAME}` (`workspaceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Workspace",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "workspaceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "GlobalTextDisplaySettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `text_display_settings_strongsMode` INTEGER DEFAULT NULL, `text_display_settings_showMorphology` INTEGER DEFAULT NULL, `text_display_settings_showFootNotes` INTEGER DEFAULT NULL, `text_display_settings_showFootNotesInline` INTEGER DEFAULT NULL, `text_display_settings_expandXrefs` INTEGER DEFAULT NULL, `text_display_settings_showXrefs` INTEGER DEFAULT NULL, `text_display_settings_showRedLetters` INTEGER DEFAULT NULL, `text_display_settings_showSectionTitles` INTEGER DEFAULT NULL, `text_display_settings_showVerseNumbers` INTEGER DEFAULT NULL, `text_display_settings_showVersePerLine` INTEGER DEFAULT NULL, `text_display_settings_showBookmarks` INTEGER DEFAULT NULL, `text_display_settings_showMyNotes` INTEGER DEFAULT NULL, `text_display_settings_justifyText` INTEGER DEFAULT NULL, `text_display_settings_hyphenation` INTEGER DEFAULT NULL, `text_display_settings_topMargin` INTEGER DEFAULT NULL, `text_display_settings_fontSize` INTEGER DEFAULT NULL, `text_display_settings_fontFamily` TEXT DEFAULT NULL, `text_display_settings_lineSpacing` INTEGER DEFAULT NULL, `text_display_settings_bookmarksHideLabels` TEXT DEFAULT NULL, `text_display_settings_showPageNumber` INTEGER DEFAULT NULL, `text_display_settings_infiniteScroll` INTEGER DEFAULT NULL, `text_display_settings_nonStrongsWordItalic` INTEGER DEFAULT NULL, `text_display_settings_showMarkAsReadButton` INTEGER DEFAULT NULL, `text_display_settings_showTitleScrollButton` INTEGER DEFAULT NULL, `text_display_settings_showMemorizationIndicators` INTEGER DEFAULT NULL, `text_display_settings_autoTrackReading` INTEGER DEFAULT NULL, `text_display_settings_showAiDocMarkers` INTEGER DEFAULT NULL, `text_display_settings_pageScrollAmount` INTEGER DEFAULT NULL, `text_display_settings_scrollHelperLines` INTEGER DEFAULT NULL, `text_display_settings_scrollHelperLineStyle` INTEGER DEFAULT NULL, `text_display_settings_showPageButtons` INTEGER DEFAULT NULL, `text_display_settings_showOrdinals` INTEGER DEFAULT NULL, `text_display_settings_showReadingProgress` INTEGER DEFAULT NULL, `text_display_settings_margin_size_marginLeft` INTEGER DEFAULT NULL, `text_display_settings_margin_size_marginRight` INTEGER DEFAULT NULL, `text_display_settings_margin_size_maxWidth` INTEGER DEFAULT NULL, `text_display_settings_colors_dayTextColor` INTEGER DEFAULT NULL, `text_display_settings_colors_dayBackground` INTEGER DEFAULT NULL, `text_display_settings_colors_dayNoise` INTEGER DEFAULT NULL, `text_display_settings_colors_nightTextColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightBackground` INTEGER DEFAULT NULL, `text_display_settings_colors_nightNoise` INTEGER DEFAULT NULL, `text_display_settings_colors_dayBackgroundImage` TEXT DEFAULT NULL, `text_display_settings_colors_nightBackgroundImage` TEXT DEFAULT NULL, `text_display_settings_colors_dayBackgroundImageOpacity` INTEGER DEFAULT NULL, `text_display_settings_colors_nightBackgroundImageOpacity` INTEGER DEFAULT NULL, `text_display_settings_colors_dayLinkColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightLinkColor` INTEGER DEFAULT NULL, `text_display_settings_colors_dayVerseNumberColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightVerseNumberColor` INTEGER DEFAULT NULL, `text_display_settings_colors_dayHeadingColor` INTEGER DEFAULT NULL, `text_display_settings_colors_nightHeadingColor` INTEGER DEFAULT NULL, `text_display_settings_colors_themeName` TEXT DEFAULT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textDisplaySettings.strongsMode",
+            "columnName": "text_display_settings_strongsMode",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMorphology",
+            "columnName": "text_display_settings_showMorphology",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showFootNotes",
+            "columnName": "text_display_settings_showFootNotes",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showFootNotesInline",
+            "columnName": "text_display_settings_showFootNotesInline",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.expandXrefs",
+            "columnName": "text_display_settings_expandXrefs",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showXrefs",
+            "columnName": "text_display_settings_showXrefs",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showRedLetters",
+            "columnName": "text_display_settings_showRedLetters",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showSectionTitles",
+            "columnName": "text_display_settings_showSectionTitles",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showVerseNumbers",
+            "columnName": "text_display_settings_showVerseNumbers",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showVersePerLine",
+            "columnName": "text_display_settings_showVersePerLine",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showBookmarks",
+            "columnName": "text_display_settings_showBookmarks",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMyNotes",
+            "columnName": "text_display_settings_showMyNotes",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.justifyText",
+            "columnName": "text_display_settings_justifyText",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.hyphenation",
+            "columnName": "text_display_settings_hyphenation",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.topMargin",
+            "columnName": "text_display_settings_topMargin",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.fontSize",
+            "columnName": "text_display_settings_fontSize",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.fontFamily",
+            "columnName": "text_display_settings_fontFamily",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.lineSpacing",
+            "columnName": "text_display_settings_lineSpacing",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.bookmarksHideLabels",
+            "columnName": "text_display_settings_bookmarksHideLabels",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showPageNumber",
+            "columnName": "text_display_settings_showPageNumber",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.infiniteScroll",
+            "columnName": "text_display_settings_infiniteScroll",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.nonStrongsWordItalic",
+            "columnName": "text_display_settings_nonStrongsWordItalic",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMarkAsReadButton",
+            "columnName": "text_display_settings_showMarkAsReadButton",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showTitleScrollButton",
+            "columnName": "text_display_settings_showTitleScrollButton",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showMemorizationIndicators",
+            "columnName": "text_display_settings_showMemorizationIndicators",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.autoTrackReading",
+            "columnName": "text_display_settings_autoTrackReading",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showAiDocMarkers",
+            "columnName": "text_display_settings_showAiDocMarkers",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.pageScrollAmount",
+            "columnName": "text_display_settings_pageScrollAmount",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.scrollHelperLines",
+            "columnName": "text_display_settings_scrollHelperLines",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.scrollHelperLineStyle",
+            "columnName": "text_display_settings_scrollHelperLineStyle",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showPageButtons",
+            "columnName": "text_display_settings_showPageButtons",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showOrdinals",
+            "columnName": "text_display_settings_showOrdinals",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.showReadingProgress",
+            "columnName": "text_display_settings_showReadingProgress",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.marginSize.marginLeft",
+            "columnName": "text_display_settings_margin_size_marginLeft",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.marginSize.marginRight",
+            "columnName": "text_display_settings_margin_size_marginRight",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.marginSize.maxWidth",
+            "columnName": "text_display_settings_margin_size_maxWidth",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayTextColor",
+            "columnName": "text_display_settings_colors_dayTextColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayBackground",
+            "columnName": "text_display_settings_colors_dayBackground",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayNoise",
+            "columnName": "text_display_settings_colors_dayNoise",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightTextColor",
+            "columnName": "text_display_settings_colors_nightTextColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightBackground",
+            "columnName": "text_display_settings_colors_nightBackground",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightNoise",
+            "columnName": "text_display_settings_colors_nightNoise",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayBackgroundImage",
+            "columnName": "text_display_settings_colors_dayBackgroundImage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightBackgroundImage",
+            "columnName": "text_display_settings_colors_nightBackgroundImage",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayBackgroundImageOpacity",
+            "columnName": "text_display_settings_colors_dayBackgroundImageOpacity",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightBackgroundImageOpacity",
+            "columnName": "text_display_settings_colors_nightBackgroundImageOpacity",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayLinkColor",
+            "columnName": "text_display_settings_colors_dayLinkColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightLinkColor",
+            "columnName": "text_display_settings_colors_nightLinkColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayVerseNumberColor",
+            "columnName": "text_display_settings_colors_dayVerseNumberColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightVerseNumberColor",
+            "columnName": "text_display_settings_colors_nightVerseNumberColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.dayHeadingColor",
+            "columnName": "text_display_settings_colors_dayHeadingColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.nightHeadingColor",
+            "columnName": "text_display_settings_colors_nightHeadingColor",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "textDisplaySettings.colors.themeName",
+            "columnName": "text_display_settings_colors_themeName",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "LogEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tableName` TEXT NOT NULL, `entityId1` BLOB NOT NULL, `entityId2` BLOB NOT NULL, `type` TEXT NOT NULL, `lastUpdated` INTEGER NOT NULL DEFAULT 0, `sourceDevice` TEXT NOT NULL, PRIMARY KEY(`tableName`, `entityId1`, `entityId2`))",
+        "fields": [
+          {
+            "fieldPath": "tableName",
+            "columnName": "tableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId1",
+            "columnName": "entityId1",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId2",
+            "columnName": "entityId2",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "lastUpdated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tableName",
+            "entityId1",
+            "entityId2"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LogEntry_lastUpdated",
+            "unique": false,
+            "columnNames": [
+              "lastUpdated"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_lastUpdated` ON `${TABLE_NAME}` (`lastUpdated`)"
+          },
+          {
+            "name": "index_LogEntry_sourceDevice",
+            "unique": false,
+            "columnNames": [
+              "sourceDevice"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_LogEntry_sourceDevice` ON `${TABLE_NAME}` (`sourceDevice`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SyncConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`keyName` TEXT NOT NULL, `stringValue` TEXT, `longValue` INTEGER, `booleanValue` INTEGER, PRIMARY KEY(`keyName`))",
+        "fields": [
+          {
+            "fieldPath": "keyName",
+            "columnName": "keyName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValue",
+            "columnName": "stringValue",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longValue",
+            "columnName": "longValue",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "booleanValue",
+            "columnName": "booleanValue",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "keyName"
+          ]
+        }
+      },
+      {
+        "tableName": "SyncStatus",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceDevice` TEXT NOT NULL, `patchNumber` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `appliedDate` INTEGER NOT NULL, PRIMARY KEY(`sourceDevice`, `patchNumber`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDevice",
+            "columnName": "sourceDevice",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchNumber",
+            "columnName": "patchNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedDate",
+            "columnName": "appliedDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceDevice",
+            "patchNumber"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8f2172100503577bd9903cbfdf541cb4')"
+    ]
+  }
+}

--- a/app/src/main/java/net/bible/android/database/WorkspaceEntities.kt
+++ b/app/src/main/java/net/bible/android/database/WorkspaceEntities.kt
@@ -151,6 +151,13 @@ class WorkspaceEntities {
         @ColumnInfo(defaultValue = "NULL") var nightBackgroundImage: String?,
         @ColumnInfo(defaultValue = "NULL") var dayBackgroundImageOpacity: Int?,
         @ColumnInfo(defaultValue = "NULL") var nightBackgroundImageOpacity: Int?,
+        @ColumnInfo(defaultValue = "NULL") var dayLinkColor: Int? = null,
+        @ColumnInfo(defaultValue = "NULL") var nightLinkColor: Int? = null,
+        @ColumnInfo(defaultValue = "NULL") var dayVerseNumberColor: Int? = null,
+        @ColumnInfo(defaultValue = "NULL") var nightVerseNumberColor: Int? = null,
+        @ColumnInfo(defaultValue = "NULL") var dayHeadingColor: Int? = null,
+        @ColumnInfo(defaultValue = "NULL") var nightHeadingColor: Int? = null,
+        @ColumnInfo(defaultValue = "NULL") var themeName: String? = null,
     ) {
         // This is saved to database in WorkspaceSettings. Here just to get it through to activities in SettingsBundle
         @Ignore var workspaceColor: Int? = null
@@ -180,6 +187,13 @@ class WorkspaceEntities {
                 nightBackgroundImage = override.nightBackgroundImage ?: nightBackgroundImage,
                 dayBackgroundImageOpacity = override.dayBackgroundImageOpacity ?: dayBackgroundImageOpacity,
                 nightBackgroundImageOpacity = override.nightBackgroundImageOpacity ?: nightBackgroundImageOpacity,
+                dayLinkColor = override.dayLinkColor ?: dayLinkColor,
+                nightLinkColor = override.nightLinkColor ?: nightLinkColor,
+                dayVerseNumberColor = override.dayVerseNumberColor ?: dayVerseNumberColor,
+                nightVerseNumberColor = override.nightVerseNumberColor ?: nightVerseNumberColor,
+                dayHeadingColor = override.dayHeadingColor ?: dayHeadingColor,
+                nightHeadingColor = override.nightHeadingColor ?: nightHeadingColor,
+                themeName = override.themeName ?: themeName,
             )
         }
 

--- a/app/src/main/java/net/bible/android/database/migrations/WorkspacesMigrations.kt
+++ b/app/src/main/java/net/bible/android/database/migrations/WorkspacesMigrations.kt
@@ -302,6 +302,19 @@ private val addBackgroundImage = makeMigration(23..24) { _db ->
     }
 }
 
+private val addColorThemePresets = makeMigration(24..25) { _db ->
+    for (table in listOf("Workspace", "PageManager", "GlobalTextDisplaySettings")) {
+        for (col in listOf(
+            "dayLinkColor", "nightLinkColor",
+            "dayVerseNumberColor", "nightVerseNumberColor",
+            "dayHeadingColor", "nightHeadingColor",
+        )) {
+            _db.execSQL("ALTER TABLE `$table` ADD COLUMN `text_display_settings_colors_$col` INTEGER DEFAULT NULL")
+        }
+        _db.execSQL("ALTER TABLE `$table` ADD COLUMN `text_display_settings_colors_themeName` TEXT DEFAULT NULL")
+    }
+}
+
 val workspacesMigrations: Array<Migration> = arrayOf(
     resetMaximizedWindowId,
     removeFavouriteLabels,
@@ -326,6 +339,7 @@ val workspacesMigrations: Array<Migration> = arrayOf(
     addShowOrdinals,
     addShowReadingProgress,
     addBackgroundImage,
+    addColorThemePresets,
 )
 
-const val WORKSPACE_DATABASE_VERSION = 24
+const val WORKSPACE_DATABASE_VERSION = 25

--- a/app/src/main/java/net/bible/android/view/activity/settings/ColorSettings.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/ColorSettings.kt
@@ -38,6 +38,12 @@ import net.bible.service.common.AndBibleAddons
 class ColorSettingsDataStore(val activity: ColorSettingsActivity): PreferenceDataStore() {
     val colors get() = activity.colors
 
+    /** Keys of the color pickers whose values a [ColorThemePreset] stamps. Editing any of
+     * these by hand clears the selected theme (→ "Custom"). */
+    private val presetPaletteKeys = setOf(
+        "text_color_day", "text_color_night", "background_color_day", "background_color_night",
+    )
+
     override fun putInt(key: String?, value: Int) {
         when(key) {
             "text_color_day" -> colors.dayTextColor = value
@@ -50,10 +56,11 @@ class ColorSettingsDataStore(val activity: ColorSettingsActivity): PreferenceDat
             "background_image_opacity_night" -> colors.nightBackgroundImageOpacity = value
             "workspace_color" -> colors.workspaceColor = value
         }
-        // Editing any individual reading-palette color manually means it's no longer one of
-        // the built-in presets. workspace_color is a workspace-level setting (not part of the
-        // reading palette itself), so it does not clear the selected theme.
-        if (key != "workspace_color") {
+        // Editing one of the palette colors a preset stamps means the colors no longer match a
+        // built-in preset, so switch the selector to "Custom". Only these keys are part of the
+        // preset palette; noise, background-image opacity and workspace_color are not, so editing
+        // them leaves the selected theme intact.
+        if (key in presetPaletteKeys && colors.themeName != null) {
             colors.themeName = null
             // Flip the theme selector to "Custom" right away, rather than leaving it showing
             // the stale preset name until the screen is reopened.

--- a/app/src/main/java/net/bible/android/view/activity/settings/ColorSettings.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/ColorSettings.kt
@@ -24,6 +24,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceDataStore
 import androidx.preference.PreferenceFragmentCompat
@@ -49,6 +50,15 @@ class ColorSettingsDataStore(val activity: ColorSettingsActivity): PreferenceDat
             "background_image_opacity_night" -> colors.nightBackgroundImageOpacity = value
             "workspace_color" -> colors.workspaceColor = value
         }
+        // Editing any individual reading-palette color manually means it's no longer one of
+        // the built-in presets. workspace_color is a workspace-level setting (not part of the
+        // reading palette itself), so it does not clear the selected theme.
+        if (key != "workspace_color") {
+            colors.themeName = null
+            // Flip the theme selector to "Custom" right away, rather than leaving it showing
+            // the stale preset name until the screen is reopened.
+            activity.refreshColorPreferences()
+        }
         activity.setDirty()
     }
 
@@ -66,6 +76,19 @@ class ColorSettingsDataStore(val activity: ColorSettingsActivity): PreferenceDat
             else -> defValue
         }
     }
+
+    override fun putString(key: String?, value: String?) {
+        if (key == "color_theme") {
+            val preset = ColorThemePreset.byId(value)
+            if (preset != null) preset.applyTo(colors) else colors.themeName = null
+            activity.setDirty()
+            activity.refreshColorPreferences()
+        }
+    }
+
+    override fun getString(key: String?, defValue: String?): String? {
+        return if (key == "color_theme") colors.themeName ?: "" else defValue
+    }
 }
 
 class ColorSettingsActivity: ActivityBase() {
@@ -77,6 +100,13 @@ class ColorSettingsActivity: ActivityBase() {
     internal var workspaceSettings: WorkspaceEntities.WorkspaceSettings? = null
     private var dirty = false
     private var reset = false
+    internal var fragment: ColorSettingsFragment? = null
+
+    /** Called by [ColorSettingsDataStore] after a theme preset has stamped new colors,
+     * so the on-screen ListPreference and color pickers reflect the new values. */
+    fun refreshColorPreferences() {
+        fragment?.refreshSummariesAndTheme()
+    }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.text_options_opts, menu)
@@ -129,9 +159,11 @@ class ColorSettingsActivity: ActivityBase() {
         dirty = false
         reset = false
 
+        val frag = ColorSettingsFragment(isWindow = settingsBundle.windowId != null)
+        fragment = frag
         supportFragmentManager
             .beginTransaction()
-            .replace(R.id.settings_container, ColorSettingsFragment(isWindow = settingsBundle.windowId != null))
+            .replace(R.id.settings_container, frag)
             .commit()
 
         if(settingsBundle.windowId != null) {
@@ -208,5 +240,40 @@ class ColorSettingsFragment(val isWindow: Boolean = false): PreferenceFragmentCo
         val activity = activity as ColorSettingsActivity
         findPreference<Preference>("background_image_day")?.summary = nameFor(activity.colors.dayBackgroundImage)
         findPreference<Preference>("background_image_night")?.summary = nameFor(activity.colors.nightBackgroundImage)
+    }
+
+    /** Keys of the color pickers whose value can be changed "from underneath them" by
+     * applying a [ColorThemePreset], i.e. without the user interacting with that specific
+     * picker. */
+    private val colorPickerKeys = listOf(
+        "text_color_day", "text_color_night",
+        "background_color_day", "background_color_night",
+    )
+
+    /**
+     * Re-syncs the UI after [ColorSettingsDataStore] has applied (or cleared) a color theme
+     * preset directly onto the underlying [WorkspaceEntities.Colors] object.
+     *
+     * `ColorPreferenceCompat` caches the color it displays in a private field that is only
+     * populated from the `PreferenceDataStore` when the preference is (re)attached to its
+     * `PreferenceGroup` (`Preference.onAttachedToHierarchy` -> `dispatchSetInitialValue` ->
+     * `onSetInitialValue` -> `getPersistedInt`). Calling `notifyChanged()` alone would just
+     * redraw the *stale* cached value, since it doesn't cause that re-read. There is no public
+     * API on `ColorPreferenceCompat` to pull a fresh value from the data store without also
+     * persisting/callback side effects, so the correct, side-effect-free way to force a re-read
+     * is to detach and reattach each affected preference from its `PreferenceGroup`.
+     */
+    fun refreshSummariesAndTheme() {
+        val activity = activity as? ColorSettingsActivity ?: return
+        // Re-sync the ListPreference selection with the (possibly changed) themeName.
+        findPreference<ListPreference>("color_theme")?.value = activity.colors.themeName ?: ""
+        // Force each color picker to re-read its value from the datastore (see kdoc above).
+        for (key in colorPickerKeys) {
+            val preference = findPreference<Preference>(key) ?: continue
+            val parent = preference.parent ?: continue
+            parent.removePreference(preference)
+            parent.addPreference(preference)
+        }
+        updateImageSummaries()
     }
 }

--- a/app/src/main/java/net/bible/android/view/activity/settings/ColorSettings.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/ColorSettings.kt
@@ -59,9 +59,10 @@ class ColorSettingsDataStore(val activity: ColorSettingsActivity): PreferenceDat
         // Editing one of the palette colors a preset stamps means the colors no longer match a
         // built-in preset, so switch the selector to "Custom". Only these keys are part of the
         // preset palette; noise, background-image opacity and workspace_color are not, so editing
-        // them leaves the selected theme intact.
-        if (key in presetPaletteKeys && colors.themeName != null) {
-            colors.themeName = null
+        // them leaves the selected theme intact. We store the explicit CUSTOM_ID sentinel (not
+        // null) so the Custom choice survives inheritance merging with a parent preset.
+        if (key != null && key in presetPaletteKeys && colors.themeName != ColorThemePreset.CUSTOM_ID) {
+            colors.themeName = ColorThemePreset.CUSTOM_ID
             // Flip the theme selector to "Custom" right away, rather than leaving it showing
             // the stale preset name until the screen is reopened.
             activity.refreshColorPreferences()
@@ -85,16 +86,24 @@ class ColorSettingsDataStore(val activity: ColorSettingsActivity): PreferenceDat
     }
 
     override fun putString(key: String?, value: String?) {
-        if (key == "color_theme") {
-            val preset = ColorThemePreset.byId(value)
-            if (preset != null) preset.applyTo(colors) else colors.themeName = null
-            activity.setDirty()
-            activity.refreshColorPreferences()
-        }
+        if (key != "color_theme") return
+        // Normalize both sides to a concrete id so no-op changes are detected. A ListPreference
+        // persists its current value when it is attached, so this runs during inflation too; only
+        // act when the requested theme actually differs, otherwise merely opening the screen would
+        // mark it dirty and flatten inherited settings into a local override.
+        val requested = ColorThemePreset.byId(value)?.id ?: ColorThemePreset.CUSTOM_ID
+        val current = colors.themeName ?: ColorThemePreset.CUSTOM_ID
+        if (requested == current) return
+
+        val preset = ColorThemePreset.byId(requested)
+        if (preset != null) preset.applyTo(colors) else colors.themeName = ColorThemePreset.CUSTOM_ID
+        activity.setDirty()
+        activity.refreshColorPreferences()
     }
 
     override fun getString(key: String?, defValue: String?): String? {
-        return if (key == "color_theme") colors.themeName ?: "" else defValue
+        // null themeName (inherited, never explicitly set) displays as Custom.
+        return if (key == "color_theme") colors.themeName ?: ColorThemePreset.CUSTOM_ID else defValue
     }
 }
 

--- a/app/src/main/java/net/bible/android/view/activity/settings/ColorThemePreset.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/ColorThemePreset.kt
@@ -79,6 +79,12 @@ enum class ColorThemePreset(
     }
 
     companion object {
+        /** Explicit "no preset" sentinel. Stored in [WorkspaceEntities.Colors.themeName] when the
+         * user picks Custom or hand-edits a palette color. Unlike `null` (which means "inherit from
+         * a parent level"), this non-null value survives [WorkspaceEntities.Colors.merge] so an
+         * explicit Custom choice at a window/workspace is not overridden by a parent's preset. */
+        const val CUSTOM_ID = "custom"
+
         fun byId(id: String?): ColorThemePreset? =
             if (id.isNullOrEmpty()) null else entries.find { it.id == id }
     }

--- a/app/src/main/java/net/bible/android/view/activity/settings/ColorThemePreset.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/ColorThemePreset.kt
@@ -46,7 +46,23 @@ enum class ColorThemePreset(
         0xFFF8F8F2.toInt(), 0xFF282A36.toInt(), 0xFF8BE9FD.toInt(), 0xFF6272A4.toInt(), 0xFFBD93F9.toInt()),
     SEPIA("sepia", R.string.color_theme_sepia,
         0xFF5B4636.toInt(), 0xFFF4ECD8.toInt(), 0xFF8B5A2B.toInt(), 0xFFA1887F.toInt(), 0xFF7B4F2C.toInt(),
-        0xFFD8C8B0.toInt(), 0xFF2B2622.toInt(), 0xFFC9A066.toInt(), 0xFF8A7A68.toInt(), 0xFFD9B382.toInt());
+        0xFFD8C8B0.toInt(), 0xFF2B2622.toInt(), 0xFFC9A066.toInt(), 0xFF8A7A68.toInt(), 0xFFD9B382.toInt()),
+    // Catppuccin: Latte (day) + Mocha (night)
+    CATPPUCCIN("catppuccin", R.string.color_theme_catppuccin,
+        0xFF4C4F69.toInt(), 0xFFEFF1F5.toInt(), 0xFF1E66F5.toInt(), 0xFF6C6F85.toInt(), 0xFF8839EF.toInt(),
+        0xFFCDD6F4.toInt(), 0xFF1E1E2E.toInt(), 0xFF89B4FA.toInt(), 0xFFA6ADC8.toInt(), 0xFFCBA6F7.toInt()),
+    // Tokyo Night: Day + Night
+    TOKYO_NIGHT("tokyo_night", R.string.color_theme_tokyo_night,
+        0xFF3760BF.toInt(), 0xFFE1E2E7.toInt(), 0xFF2E7DE9.toInt(), 0xFF848CB5.toInt(), 0xFF9854F1.toInt(),
+        0xFFC0CAF5.toInt(), 0xFF1A1B26.toInt(), 0xFF7AA2F7.toInt(), 0xFF565F89.toInt(), 0xFFBB9AF7.toInt()),
+    // One Dark / One Light (Atom)
+    ONE_DARK("one_dark", R.string.color_theme_one_dark,
+        0xFF383A42.toInt(), 0xFFFAFAFA.toInt(), 0xFF4078F2.toInt(), 0xFFA0A1A7.toInt(), 0xFFA626A4.toInt(),
+        0xFFABB2BF.toInt(), 0xFF282C34.toInt(), 0xFF61AFEF.toInt(), 0xFF5C6370.toInt(), 0xFFC678DD.toInt()),
+    // Monokai: classic (night) + synthesized light (day)
+    MONOKAI("monokai", R.string.color_theme_monokai,
+        0xFF49483E.toInt(), 0xFFFAFAFA.toInt(), 0xFF0089BD.toInt(), 0xFFA59F85.toInt(), 0xFFE0007F.toInt(),
+        0xFFF8F8F2.toInt(), 0xFF272822.toInt(), 0xFF66D9EF.toInt(), 0xFF75715E.toInt(), 0xFFF92672.toInt());
 
     fun applyTo(c: WorkspaceEntities.Colors) {
         c.dayTextColor = dayText

--- a/app/src/main/java/net/bible/android/view/activity/settings/ColorThemePreset.kt
+++ b/app/src/main/java/net/bible/android/view/activity/settings/ColorThemePreset.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Sykerö Software / Tuomas Airaksinen and the AndBible contributors.
+ *
+ * This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+ *
+ * AndBible is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with AndBible.
+ * If not, see http://www.gnu.org/licenses/.
+ */
+
+package net.bible.android.view.activity.settings
+
+import net.bible.android.activity.R
+import net.bible.android.database.WorkspaceEntities
+
+/**
+ * Built-in named color palettes. Selecting one stamps its full day + night palette
+ * onto a [WorkspaceEntities.Colors] and records [id] in [WorkspaceEntities.Colors.themeName].
+ * Editing any individual color afterwards clears themeName back to Custom
+ * (handled in ColorSettingsDataStore).
+ */
+enum class ColorThemePreset(
+    val id: String,
+    val labelRes: Int,
+    val dayText: Int, val dayBg: Int, val dayLink: Int, val dayVerse: Int, val dayHeading: Int,
+    val nightText: Int, val nightBg: Int, val nightLink: Int, val nightVerse: Int, val nightHeading: Int,
+) {
+    GRUVBOX("gruvbox", R.string.color_theme_gruvbox,
+        0xFF3C3836.toInt(), 0xFFFBF1C7.toInt(), 0xFF076678.toInt(), 0xFF7C6F64.toInt(), 0xFFB57614.toInt(),
+        0xFFEBDBB2.toInt(), 0xFF282828.toInt(), 0xFF83A598.toInt(), 0xFFA89984.toInt(), 0xFFFABD2F.toInt()),
+    NORD("nord", R.string.color_theme_nord,
+        0xFF2E3440.toInt(), 0xFFECEFF4.toInt(), 0xFF5E81AC.toInt(), 0xFF4C566A.toInt(), 0xFFB48EAD.toInt(),
+        0xFFD8DEE9.toInt(), 0xFF2E3440.toInt(), 0xFF88C0D0.toInt(), 0xFF7B88A1.toInt(), 0xFF81A1C1.toInt()),
+    SOLARIZED("solarized", R.string.color_theme_solarized,
+        0xFF657B83.toInt(), 0xFFFDF6E3.toInt(), 0xFF268BD2.toInt(), 0xFF93A1A1.toInt(), 0xFFB58900.toInt(),
+        0xFF839496.toInt(), 0xFF002B36.toInt(), 0xFF268BD2.toInt(), 0xFF586E75.toInt(), 0xFFB58900.toInt()),
+    DRACULA("dracula", R.string.color_theme_dracula,
+        0xFF1F1F1F.toInt(), 0xFFF8F8F2.toInt(), 0xFF036A96.toInt(), 0xFF6272A4.toInt(), 0xFF644AC9.toInt(),
+        0xFFF8F8F2.toInt(), 0xFF282A36.toInt(), 0xFF8BE9FD.toInt(), 0xFF6272A4.toInt(), 0xFFBD93F9.toInt()),
+    SEPIA("sepia", R.string.color_theme_sepia,
+        0xFF5B4636.toInt(), 0xFFF4ECD8.toInt(), 0xFF8B5A2B.toInt(), 0xFFA1887F.toInt(), 0xFF7B4F2C.toInt(),
+        0xFFD8C8B0.toInt(), 0xFF2B2622.toInt(), 0xFFC9A066.toInt(), 0xFF8A7A68.toInt(), 0xFFD9B382.toInt());
+
+    fun applyTo(c: WorkspaceEntities.Colors) {
+        c.dayTextColor = dayText
+        c.dayBackground = dayBg
+        c.dayLinkColor = dayLink
+        c.dayVerseNumberColor = dayVerse
+        c.dayHeadingColor = dayHeading
+        c.nightTextColor = nightText
+        c.nightBackground = nightBg
+        c.nightLinkColor = nightLink
+        c.nightVerseNumberColor = nightVerse
+        c.nightHeadingColor = nightHeading
+        c.themeName = id
+    }
+
+    companion object {
+        fun byId(id: String?): ColorThemePreset? =
+            if (id.isNullOrEmpty()) null else entries.find { it.id == id }
+    }
+}

--- a/app/src/main/res/values/color_theme_arrays.xml
+++ b/app/src/main/res/values/color_theme_arrays.xml
@@ -30,7 +30,7 @@
         <item>@string/color_theme_monokai</item>
     </string-array>
     <string-array name="color_theme_values" translatable="false">
-        <item></item>
+        <item>custom</item>
         <item>gruvbox</item>
         <item>nord</item>
         <item>solarized</item>

--- a/app/src/main/res/values/color_theme_arrays.xml
+++ b/app/src/main/res/values/color_theme_arrays.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 Sykerö Software / Tuomas Airaksinen and the AndBible contributors.
+  ~
+  ~ This file is part of AndBible: Bible Study (http://github.com/AndBible/and-bible).
+  ~
+  ~ AndBible is free software: you can redistribute it and/or modify it under the
+  ~ terms of the GNU General Public License as published by the Free Software Foundation,
+  ~ either version 3 of the License, or (at your option) any later version.
+  ~
+  ~ AndBible is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with AndBible.
+  ~ If not, see http://www.gnu.org/licenses/.
+  -->
+
+<resources>
+    <string-array name="color_theme_entries">
+        <item>@string/color_theme_custom</item>
+        <item>@string/color_theme_gruvbox</item>
+        <item>@string/color_theme_nord</item>
+        <item>@string/color_theme_solarized</item>
+        <item>@string/color_theme_dracula</item>
+        <item>@string/color_theme_sepia</item>
+    </string-array>
+    <string-array name="color_theme_values" translatable="false">
+        <item></item>
+        <item>gruvbox</item>
+        <item>nord</item>
+        <item>solarized</item>
+        <item>dracula</item>
+        <item>sepia</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/color_theme_arrays.xml
+++ b/app/src/main/res/values/color_theme_arrays.xml
@@ -24,6 +24,10 @@
         <item>@string/color_theme_solarized</item>
         <item>@string/color_theme_dracula</item>
         <item>@string/color_theme_sepia</item>
+        <item>@string/color_theme_catppuccin</item>
+        <item>@string/color_theme_tokyo_night</item>
+        <item>@string/color_theme_one_dark</item>
+        <item>@string/color_theme_monokai</item>
     </string-array>
     <string-array name="color_theme_values" translatable="false">
         <item></item>
@@ -32,5 +36,9 @@
         <item>solarized</item>
         <item>dracula</item>
         <item>sepia</item>
+        <item>catppuccin</item>
+        <item>tokyo_night</item>
+        <item>one_dark</item>
+        <item>monokai</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,6 +323,13 @@
     <string name="prefs_noise_title">Background noise</string>
     <string name="prefs_noise_summary">Adding some noise to background might make it more comfortable to eyes. </string>
 
+    <string name="color_theme">Color theme</string>
+    <string name="color_theme_custom">Custom</string>
+    <string name="color_theme_gruvbox">Gruvbox</string>
+    <string name="color_theme_nord">Nord</string>
+    <string name="color_theme_solarized">Solarized</string>
+    <string name="color_theme_dracula">Dracula</string>
+    <string name="color_theme_sepia">Sepia</string>
 
     <!-- Window -->
     <string name="new_window">New window</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,6 +330,10 @@
     <string name="color_theme_solarized">Solarized</string>
     <string name="color_theme_dracula">Dracula</string>
     <string name="color_theme_sepia">Sepia</string>
+    <string name="color_theme_catppuccin">Catppuccin</string>
+    <string name="color_theme_tokyo_night">Tokyo Night</string>
+    <string name="color_theme_one_dark">One Dark</string>
+    <string name="color_theme_monokai">Monokai</string>
 
     <!-- Window -->
     <string name="new_window">New window</string>

--- a/app/src/main/res/xml/color_settings.xml
+++ b/app/src/main/res/xml/color_settings.xml
@@ -26,6 +26,15 @@
         android:title="@string/color_workspace"
         />
 
+    <ListPreference
+        android:key="color_theme"
+        android:title="@string/color_theme"
+        android:entries="@array/color_theme_entries"
+        android:entryValues="@array/color_theme_values"
+        android:defaultValue=""
+        app:useSimpleSummaryProvider="true"
+        />
+
     <PreferenceCategory
         android:title="@string/colors_day_mode_title"
         >

--- a/app/src/test/java/net/bible/android/database/ColorsMergeTest.kt
+++ b/app/src/test/java/net/bible/android/database/ColorsMergeTest.kt
@@ -49,4 +49,23 @@ class ColorsMergeTest {
         assertEquals(100, colors.dayBackgroundImageOpacity)
         assertEquals(100, colors.nightBackgroundImageOpacity)
     }
+
+    @Test
+    fun mergeFallsBackAccentAndThemePerField() {
+        val base = blank().copy(dayLinkColor = 0x111111, dayVerseNumberColor = 0x222222, themeName = "gruvbox")
+        val override = blank().copy(nightLinkColor = 0x333333, dayHeadingColor = 0x444444)
+        val merged = base.merge(override)
+        assertEquals(0x111111, merged.dayLinkColor)
+        assertEquals(0x333333, merged.nightLinkColor)
+        assertEquals(0x222222, merged.dayVerseNumberColor)
+        assertEquals(0x444444, merged.dayHeadingColor)
+        assertEquals("gruvbox", merged.themeName)
+    }
+
+    @Test
+    fun overrideThemeNameWins() {
+        val base = blank().copy(themeName = "gruvbox")
+        val override = blank().copy(themeName = "nord")
+        assertEquals("nord", base.merge(override).themeName)
+    }
 }

--- a/app/src/test/java/net/bible/android/view/activity/settings/ColorThemePresetTest.kt
+++ b/app/src/test/java/net/bible/android/view/activity/settings/ColorThemePresetTest.kt
@@ -1,0 +1,47 @@
+package net.bible.android.view.activity.settings
+
+import net.bible.android.database.WorkspaceEntities.Colors
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ColorThemePresetTest {
+    private fun blank() = Colors(null, null, null, null, null, null, null, null, null, null)
+
+    @Test
+    fun applyToStampsAllFieldsAndThemeName() {
+        val c = blank()
+        ColorThemePreset.GRUVBOX.applyTo(c)
+        assertEquals("gruvbox", c.themeName)
+        assertEquals(ColorThemePreset.GRUVBOX.dayText, c.dayTextColor)
+        assertEquals(ColorThemePreset.GRUVBOX.dayBg, c.dayBackground)
+        assertEquals(ColorThemePreset.GRUVBOX.dayLink, c.dayLinkColor)
+        assertEquals(ColorThemePreset.GRUVBOX.dayVerse, c.dayVerseNumberColor)
+        assertEquals(ColorThemePreset.GRUVBOX.dayHeading, c.dayHeadingColor)
+        assertEquals(ColorThemePreset.GRUVBOX.nightText, c.nightTextColor)
+        assertEquals(ColorThemePreset.GRUVBOX.nightBg, c.nightBackground)
+        assertEquals(ColorThemePreset.GRUVBOX.nightLink, c.nightLinkColor)
+        assertEquals(ColorThemePreset.GRUVBOX.nightVerse, c.nightVerseNumberColor)
+        assertEquals(ColorThemePreset.GRUVBOX.nightHeading, c.nightHeadingColor)
+    }
+
+    @Test
+    fun byIdRoundTrips() {
+        for (p in ColorThemePreset.entries) assertEquals(p, ColorThemePreset.byId(p.id))
+    }
+
+    @Test
+    fun byIdUnknownOrNullIsNull() {
+        assertNull(ColorThemePreset.byId(null))
+        assertNull(ColorThemePreset.byId(""))
+        assertNull(ColorThemePreset.byId("nonexistent"))
+    }
+
+    @Test
+    fun applyToLeavesNoiseAndImagesUntouched() {
+        val c = blank().copy(dayNoise = 30, dayBackgroundImage = "BGIMG_x")
+        ColorThemePreset.NORD.applyTo(c)
+        assertEquals(30, c.dayNoise)
+        assertEquals("BGIMG_x", c.dayBackgroundImage)
+    }
+}

--- a/app/src/test/java/net/bible/android/view/activity/settings/ColorThemePresetTest.kt
+++ b/app/src/test/java/net/bible/android/view/activity/settings/ColorThemePresetTest.kt
@@ -2,6 +2,7 @@ package net.bible.android.view.activity.settings
 
 import net.bible.android.database.WorkspaceEntities.Colors
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -43,5 +44,34 @@ class ColorThemePresetTest {
         ColorThemePreset.NORD.applyTo(c)
         assertEquals(30, c.dayNoise)
         assertEquals("BGIMG_x", c.dayBackgroundImage)
+    }
+
+    @Test
+    fun allExpectedThemesPresent() {
+        val ids = ColorThemePreset.entries.map { it.id }.toSet()
+        assertEquals(
+            setOf(
+                "gruvbox", "nord", "solarized", "dracula", "sepia",
+                "catppuccin", "tokyo_night", "one_dark", "monokai",
+            ),
+            ids,
+        )
+    }
+
+    /** Guards against a new palette that forgot to set a field: every preset must
+     * stamp all 10 color fields (non-null) plus themeName == id. */
+    @Test
+    fun everyPresetStampsAllFields() {
+        for (p in ColorThemePreset.entries) {
+            val c = blank()
+            p.applyTo(c)
+            assertEquals(p.id, c.themeName)
+            for (field in listOf(
+                c.dayTextColor, c.dayBackground, c.dayLinkColor, c.dayVerseNumberColor, c.dayHeadingColor,
+                c.nightTextColor, c.nightBackground, c.nightLinkColor, c.nightVerseNumberColor, c.nightHeadingColor,
+            )) {
+                assertNotNull("${p.id} left a color field null", field)
+            }
+        }
     }
 }

--- a/app/src/test/java/net/bible/android/view/activity/settings/ColorThemePresetTest.kt
+++ b/app/src/test/java/net/bible/android/view/activity/settings/ColorThemePresetTest.kt
@@ -36,6 +36,8 @@ class ColorThemePresetTest {
         assertNull(ColorThemePreset.byId(null))
         assertNull(ColorThemePreset.byId(""))
         assertNull(ColorThemePreset.byId("nonexistent"))
+        // The Custom sentinel is not a preset — it must not resolve to one.
+        assertNull(ColorThemePreset.byId(ColorThemePreset.CUSTOM_ID))
     }
 
     @Test


### PR DESCRIPTION
Adds named color theme presets to Color Settings: Gruvbox, Nord, Solarized, Dracula, Sepia, Catppuccin, Tokyo Night, One Dark, and Monokai.

Each preset sets text, background, link, verse number, and heading colors for both day and night mode. The selected theme is remembered and switches back to "Custom" if you edit a color by hand.